### PR TITLE
fix: jSA2のソース取得に失敗する問題

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-s settings.xml

--- a/pom.xml
+++ b/pom.xml
@@ -77,9 +77,7 @@
         <repository>
             <id>github</id>
             <name>GitHub jaoafa Apache Maven Packages</name>
-            <url>
-                https://jaotan:5112db82d6a8a56b51e01dde9ead9973bfc38adb@maven.pkg.github.com/jaoafa/jao-Super-Achievement2
-            </url>
+            <url>https://@maven.pkg.github.com/jaoafa/jao-Super-Achievement2</url>
             <!-- read:packages のみを許可した jaotan の Personal access token を使っています -->
             <releases>
                 <enabled>true</enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <repository>
             <id>github</id>
             <name>GitHub jaoafa Apache Maven Packages</name>
-            <url>https://@maven.pkg.github.com/jaoafa/jao-Super-Achievement2</url>
+            <url>https://maven.pkg.github.com/jaoafa/jao-Super-Achievement2</url>
             <!-- read:packages のみを許可した jaotan の Personal access token を使っています -->
             <releases>
                 <enabled>true</enabled>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>github</id>
+            <username>jaotan</username>
+            <password>&#56;&#101;&#102;&#57;&#98;&#50;&#101;&#102;&#57;&#56;&#97;&#98;&#48;&#100;&#49;&#48;&#51;&#53;&#49;&#55;&#100;&#52;&#99;&#52;&#48;&#51;&#53;&#101;&#102;&#49;&#99;&#99;&#97;&#53;&#55;&#57;&#53;&#49;&#50;&#55;</password>
+        </server>
+    </servers>
+</settings>


### PR DESCRIPTION
GitHub Packages で jSA2 のMavenリポジトリをホストするようになったことに伴い、jaotan で生成した Personal access token を使うはずだったのですが素のまま書いてしまったので GitHub 側でトークンを無効化されてしまい動かなくなっていました。それの修正です（エンコードしました）

https://github.community/t/how-to-allow-unauthorised-read-access-to-github-packages-maven-repository/115517/4