### PR TITLE
fix: エリトラなどの着けるものを手動でつけられない・外せない不具合の修正

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/event/Event_BlackList.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_BlackList.java
@@ -144,7 +144,7 @@ public class Event_BlackList extends MyMaidLibrary implements Listener, EventPre
         if (!bool) event.setCancelled(true);
 
         if (Materials.isArmor(target.getType()) &&
-            checkBlacklist(Blacklist.BlacklistEvent.EQUIP, target.getType(), player, player.getLocation())) {
+            !checkBlacklist(Blacklist.BlacklistEvent.EQUIP, target.getType(), player, player.getLocation())) {
             event.setCancelled(true);
         }
     }
@@ -183,7 +183,7 @@ public class Event_BlackList extends MyMaidLibrary implements Listener, EventPre
 
             ItemStack equipped = checkEquipped(event);
             if (equipped != null &&
-                checkBlacklist(Blacklist.BlacklistEvent.EQUIP, item.getType(), player, player.getLocation())) {
+                !checkBlacklist(Blacklist.BlacklistEvent.EQUIP, item.getType(), player, player.getLocation())) {
                 event.setCancelled(true);
             }
         }


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

エリトラなどの着けるものを手動でつけられない・外せない不具合の修正

## 関連する Issue

- close #315 

## チェックリスト

- 【必須】[x] [CONTRIBUTING](https://github.com/jaoafa/MyMaid4/blob/master/CONTRIBUTING.md) を読みました
- 【必須】[x] テストサーバで動作確認をしました
  - [x] ローカルサーバで動作確認しました
  - [ ] ZakuroHatのテストサーバで動作確認しました
- 【必須】[x] プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- 【必須】[x] `NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [x] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
  - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [ ] 複数のクラスにわたって使用される変数があるので、 `MyMaidData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `MyMaidLibrary` にその関数を作成し管理しています
