### PR TITLE
fix: bug, kickコマンドを引数無しで実行した際にエラーが発生する不具合の修正

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/event/Event_AntiProblemCommand.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_AntiProblemCommand.java
@@ -257,7 +257,8 @@ public class Event_AntiProblemCommand extends MyMaidLibrary implements Listener,
     static class AntiCmd_BanCmd implements AntiCommand {
         @Override
         public void execute(PlayerCommandPreprocessEvent event, Player player, String[] args) {
-            if (args[1].equalsIgnoreCase(player.getName()) ||
+            if (args.length != 0 &&
+                args[1].equalsIgnoreCase(player.getName()) ||
                 args[1].equalsIgnoreCase("me") ||
                 args[1].equalsIgnoreCase("@p") ||
                 args[1].equalsIgnoreCase("@s")) {
@@ -283,7 +284,8 @@ public class Event_AntiProblemCommand extends MyMaidLibrary implements Listener,
     static class AntiCmd_KickCmd implements AntiCommand {
         @Override
         public void execute(PlayerCommandPreprocessEvent event, Player player, String[] args) {
-            if (args[1].equalsIgnoreCase(player.getName()) ||
+            if (args.length != 0 &&
+                args[1].equalsIgnoreCase(player.getName()) ||
                 args[1].equalsIgnoreCase("me") ||
                 args[1].equalsIgnoreCase("@p") ||
                 args[1].equalsIgnoreCase("@s")) {


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

> どのような機能・コマンドを実装したり、修正したかを簡潔に説明してください

bug, kickコマンドを引数無しで実行した際にエラーが発生する不具合の修正

## 関連する Issue

> 関連する Issue がある場合は、`#1` のような形式で示してください
> マージと同時にクローズされる必要がある場合は、`close #1` のように記載してください

- close #318 

## チェックリスト

> `[ ]` を `[x]` にすることでチェックできます

- [x] 【必須】[CONTRIBUTING](https://github.com/jaoafa/MyMaid4/blob/master/CONTRIBUTING.md) を読みました
- [x] 【必須】テストサーバで動作確認をしました
  - [x] ローカルサーバで動作確認しました
  - [ ] ZakuroHatのテストサーバで動作確認しました
- [x] 【必須】プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- [x] 【必須】`NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [x] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
  - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [ ] 複数のクラスにわたって使用される変数があるので、 `MyMaidData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `MyMaidLibrary` にその関数を作成し管理しています

