### PR TITLE
fix: #328 jaoium判定条件の修正

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/event/Event_Antijaoium.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_Antijaoium.java
@@ -57,13 +57,10 @@ import java.util.*;
 
 public class Event_Antijaoium extends MyMaidLibrary implements Listener, EventPremise {
     List<Integer> heal = Arrays.asList(
-        -3,
         29,
-        125,
-        253
-    );
-    List<Integer> health_boost = Collections.singletonList(
-        -7
+        61,
+        93,
+        125
     );
     Set<String> sendHashes = new HashSet<>();
     Map<String, String> Reason = new HashMap<>(); // プレイヤー : 理由
@@ -79,20 +76,12 @@ public class Event_Antijaoium extends MyMaidLibrary implements Listener, EventPr
      * @param list PotionEffectのList
      *
      * @return jaoiumかどうか
-     *
-     * @author mine_book000
      */
     private boolean isjaoium(List<PotionEffect> list) {
         boolean jaoium = false;
         for (PotionEffect po : list) {
             if (po.getType().equals(PotionEffectType.HEAL)) {
                 if (heal.contains(po.getAmplifier())) {
-                    // アウト
-                    jaoium = true;
-                }
-            }
-            if (po.getType().equals(PotionEffectType.HEALTH_BOOST)) {
-                if (health_boost.contains(po.getAmplifier())) {
                     // アウト
                     jaoium = true;
                 }


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

jaoium判定条件の修正

## 関連する Issue

- close #328

## チェックリスト

> `[ ]` を `[x]` にすることでチェックできます

- [x] 【必須】[CONTRIBUTING](https://github.com/jaoafa/MyMaid4/blob/master/CONTRIBUTING.md) を読みました
- [x] 【必須】テストサーバで動作確認をしました
  - [x] ローカルサーバで動作確認しました
  - [ ] ZakuroHatのテストサーバで動作確認しました
- [x] 【必須】プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- [x] 【必須】`NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [x] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
  - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [ ] 複数のクラスにわたって使用される変数があるので、 `MyMaidData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `MyMaidLibrary` にその関数を作成し管理しています
