### PR TITLE
fix: #334 一部ブロックがdedmessageの対象にならない不具合の修正

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/event/Event_DedMessage.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_DedMessage.java
@@ -26,12 +26,11 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 public class Event_DedMessage extends MyMaidLibrary implements Listener, EventPremise {
     @Override
     public String description() {
-        return "コンクリートパウダーの変化を無効化します。";
+        return "dedmessageコマンドに関する処理を行います。";
     }
 
     @EventHandler
     public void onDeath(PlayerDeathEvent event) {
-        System.out.println("PlayerDeathEvent");
         Player player = event.getEntity();
         Location loc = player.getLocation();
         Player killer = player.getKiller();

--- a/src/main/java/com/jaoafa/mymaid4/lib/DedMessage.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/DedMessage.java
@@ -126,7 +126,7 @@ public class DedMessage {
             ), Vector.getMaximum(
                 details.getFirstLocation(),
                 details.getSecondLocation()
-            ))) {
+            ).add(new Vector(1, 1, 1)))) {
                 return details;
             }
         }


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

一部ブロックがdedmessageの対象にならない不具合の修正

## 関連する Issue

> 関連する Issue がある場合は、`#1` のような形式で示してください
> マージと同時にクローズされる必要がある場合は、`close #1` のように記載してください

- close #334

## チェックリスト

> `[ ]` を `[x]` にすることでチェックできます

- [x] 【必須】[CONTRIBUTING](https://github.com/jaoafa/MyMaid4/blob/master/CONTRIBUTING.md) を読みました
- [x] 【必須】テストサーバで動作確認をしました
  - [x] ローカルサーバで動作確認しました
  - [ ] ZakuroHatのテストサーバで動作確認しました
- [x] 【必須】プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- [x] 【必須】`NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [x] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
  - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [ ] 複数のクラスにわたって使用される変数があるので、 `MyMaidData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `MyMaidLibrary` にその関数を作成し管理しています

## 追加情報

> 何か追加情報がある場合は記載してください


