### PR TITLE
feat: calctree3

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Calctree.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Calctree.java
@@ -65,7 +65,7 @@ public class Cmd_Calctree extends MyMaidLibrary implements CommandPremise {
         }
         int length = region.getLength();
         int width = region.getWidth();
-        if (length <= 3 && width <= 3) {
+        if (length <= 5 && width <= 5) {
             SendMessage(player, details(), "狭すぎるので植木算出来ません。");
             return;
         }

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Calctree.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Calctree.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.BooleanArgument;
 import cloud.commandframework.context.CommandContext;
@@ -44,7 +45,7 @@ public class Cmd_Calctree extends MyMaidLibrary implements CommandPremise {
         return new MyMaidCommand.Cmd(
             builder
                 .meta(CommandMeta.DESCRIPTION, "WorldEditの選択範囲で植木算を行います。")
-                .argument(BooleanArgument.optional("placeEdgeTree", true))
+                .argument(BooleanArgument.optional("placeEdgeTree", true), ArgumentDescription.of("両端に木を置くかどうか。"))
                 .senderType(Player.class)
                 .handler(this::calcTree)
                 .build()

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Calctree.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Calctree.java
@@ -1,0 +1,123 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.mymaid4.command;
+
+import cloud.commandframework.Command;
+import cloud.commandframework.arguments.standard.BooleanArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.meta.CommandMeta;
+import com.jaoafa.mymaid4.lib.CommandPremise;
+import com.jaoafa.mymaid4.lib.MyMaidCommand;
+import com.jaoafa.mymaid4.lib.MyMaidLibrary;
+import com.sk89q.worldedit.IncompleteRegionException;
+import com.sk89q.worldedit.bukkit.WorldEditPlugin;
+import com.sk89q.worldedit.regions.Region;
+import com.sk89q.worldedit.world.World;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Cmd_Calctree extends MyMaidLibrary implements CommandPremise {
+    @Override
+    public MyMaidCommand.Detail details() {
+        return new MyMaidCommand.Detail(
+            "calctree",
+            "WorldEditの選択範囲で植木算を行います。"
+        );
+    }
+
+    @Override
+    public MyMaidCommand.Cmd register(Command.Builder<CommandSender> builder) {
+        return new MyMaidCommand.Cmd(
+            builder
+                .meta(CommandMeta.DESCRIPTION, "WorldEditの選択範囲で植木算を行います。")
+                .argument(BooleanArgument.optional("placeEdgeTree", true))
+                .senderType(Player.class)
+                .handler(this::calcTree)
+                .build()
+        );
+    }
+
+    void calcTree(CommandContext<CommandSender> context) {
+        Player player = (Player) context.getSender();
+        WorldEditPlugin we = getWorldEdit();
+        Region region = null;
+        boolean placeEdgeTree = context.getOrDefault("placeEdgeTree", true);
+        try {
+            World selectionWorld = we.getSession(player).getSelectionWorld();
+            region = we.getSession(player).getSelection(selectionWorld);
+        } catch (IncompleteRegionException e) {
+            SendMessage(player, details(), "WorldEditで範囲を指定してください。");
+            return;
+        }
+        int length = region.getLength();
+        int width = region.getWidth();
+        if (length <= 3 && width <= 3) {
+            SendMessage(player, details(), "狭すぎるので植木算出来ません。");
+            return;
+        }
+        int lengthFinal = Math.max(length, width);
+        int currentTreeNum = 2;
+        int maxTreeNum = lengthFinal / 2;
+
+        Map<Integer, Integer> result = calc(lengthFinal, currentTreeNum, maxTreeNum, placeEdgeTree);
+        //50行以上になりそうなら余りを削る
+        if (result.values().size() > 50) {
+            result.forEach((k, v) -> {
+                if (v != 0) {
+                    result.remove(k, v);
+                }
+            });
+        }
+
+        result.forEach((k, v) -> {
+            if (v == 0) {
+                SendMessage(player, details(), Component.text().append(
+                    Component.text(String.format("[余剰無し] 間隔:%s", k), NamedTextColor.GREEN)
+                ).build());
+            } else {
+                SendMessage(player, details(), Component.text().append(
+                    Component.text(String.format("[余剰有り] 間隔:%s 余剰:%s", k, v), NamedTextColor.RED)
+                ).build());
+            }
+        });
+
+    }
+
+    Map<Integer, Integer> calc(int length, int currentTreeNum, int maxTreeNum, boolean placeEdgeTree) {
+        Map<Integer, Integer> result = new HashMap<>();
+        for (; currentTreeNum < maxTreeNum; currentTreeNum++) {
+            if (placeEdgeTree) {
+                int kankaku;
+                int amari = 0;
+                kankaku = (length - currentTreeNum) / (currentTreeNum - 1);
+                if (length != (kankaku * (currentTreeNum - 1) + currentTreeNum)) {
+                    amari = length - (kankaku * (currentTreeNum - 1) + currentTreeNum);
+                }
+                result.put(kankaku, amari);
+            } else {
+                int kankaku;
+                int amari = 0;
+                kankaku = (length - currentTreeNum) / (currentTreeNum + 1);
+                if (length != (kankaku * (currentTreeNum + 1) + currentTreeNum)) {
+                    amari = length - (kankaku * (currentTreeNum + 1) + currentTreeNum);
+                }
+                result.put(kankaku, amari);
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

`/calctree true/false(両端に木を置くかどうか/Default:true)`
植木算機能を実装しました。
WEで選択した範囲を取得し、長いほう(x or z)を取得して植木算を実行します。
(選択範囲がどちらも3m以下の場合は弾かれます。)
結果が50以上ある場合は、余りが発生しない結果のみ表示します。



## 関連する Issue
#326 

## チェックリスト

> `[ ]` を `[x]` にすることでチェックできます

- [x] 【必須】[CONTRIBUTING](https://github.com/jaoafa/MyMaid4/blob/master/CONTRIBUTING.md) を読みました
- [x] 【必須】テストサーバで動作確認をしました
  - [ ] ローカルサーバで動作確認しました
  - [x] ZakuroHatのテストサーバで動作確認しました
- [x] 【必須】プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- [x] 【必須】`NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [x] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
  - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [ ] 複数のクラスにわたって使用される変数があるので、 `MyMaidData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `MyMaidLibrary` にその関数を作成し管理しています

## 追加情報

> 何か追加情報がある場合は記載してください


