### PR TITLE
feat: LookingBlock

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/event/Event_LookingBlock.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_LookingBlock.java
@@ -32,7 +32,7 @@ public class Event_LookingBlock extends MyMaidLibrary implements Listener, Event
             return; //LookingBlock以外
         }
         if (isAMRV(player)) {
-            if (player.getTargetBlock(15) == null){
+            if (player.getTargetBlock(15) == null) {
                 player.sendMessage("[LookingBlock]あなたは何も見ていません！");
                 return;
             }

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_LookingBlock.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_LookingBlock.java
@@ -1,0 +1,42 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.mymaid4.event;
+
+import com.jaoafa.mymaid4.lib.EventPremise;
+import com.jaoafa.mymaid4.lib.MyMaidLibrary;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+
+public class Event_LookingBlock extends MyMaidLibrary implements Listener, EventPremise {
+    @Override
+    public String description() {
+        return "「LookingBlock」が含まれるコマンドが実行された際に自動で見ているブロックのIDに置き換えます。";
+    }
+
+    @EventHandler
+    public void onSetHandFacingCommand(PlayerCommandPreprocessEvent event) {
+        String command = event.getMessage();
+        Player player = event.getPlayer();
+        if (!command.contains("LookingBlock")) {
+            return; //LookingBlock以外
+        }
+        if (isAMRV(player)) {
+            if (player.getTargetBlock(15) == null){
+                player.sendMessage("[LookingBlock]あなたは何も見ていません！");
+                return;
+            }
+            event.setMessage(command.replace("LookingBlock", player.getTargetBlock(15).getBlockData().getMaterial().getKey().getKey()));
+        }
+    }
+}

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_LookingBlock.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_LookingBlock.java
@@ -13,6 +13,7 @@ package com.jaoafa.mymaid4.event;
 
 import com.jaoafa.mymaid4.lib.EventPremise;
 import com.jaoafa.mymaid4.lib.MyMaidLibrary;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -28,15 +29,16 @@ public class Event_LookingBlock extends MyMaidLibrary implements Listener, Event
     public void onSetHandFacingCommand(PlayerCommandPreprocessEvent event) {
         String command = event.getMessage();
         Player player = event.getPlayer();
-        if (!command.contains("LookingBlock")) {
+        if (!command.contains("lookb")) {
             return; //LookingBlock以外
         }
+        Block lookingBlock = player.getTargetBlock(15);
         if (isAMRV(player)) {
-            if (player.getTargetBlock(15) == null) {
-                player.sendMessage("[LookingBlock]あなたは何も見ていません！");
+            if (lookingBlock == null) {
+                player.sendMessage("[LookB] あなたは何も見ていません！");
                 return;
             }
-            event.setMessage(command.replace("LookingBlock", player.getTargetBlock(15).getBlockData().getMaterial().getKey().getKey()));
+            event.setMessage(command.replace("lookb", lookingBlock.getBlockData().getMaterial().getKey().getKey()));
         }
     }
 }


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

"LookingBlock"を、プレイヤーが現在見ているブロックに置き換えて実行します
(//set LookingBlock など)

## 関連する Issue

## チェックリスト

> `[ ]` を `[x]` にすることでチェックできます

- [x] 【必須】[CONTRIBUTING](https://github.com/jaoafa/MyMaid4/blob/master/CONTRIBUTING.md) を読みました
- [x] 【必須】テストサーバで動作確認をしました
  - [ ] ローカルサーバで動作確認しました
  - [x] ZakuroHatのテストサーバで動作確認しました
- [x] 【必須】プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- [x] 【必須】`NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [ ] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
  - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [ ] 複数のクラスにわたって使用される変数があるので、 `MyMaidData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `MyMaidLibrary` にその関数を作成し管理しています

## 追加情報

> 何か追加情報がある場合は記載してください


