### PR TITLE
Feature/issue 346 jaoium

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/event/Event_Antijaoium.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_Antijaoium.java
@@ -177,7 +177,7 @@ public class Event_Antijaoium extends MyMaidLibrary implements Listener, EventPr
             sdfFormat(new Date()),
             hash,
             exists,
-            isWarning ? String.format("\n[警告] jaoiumという文字列が含まれていません: `%s`", displayName) : "")).queue();
+            isWarning ? String.format("\n**[警告]** jaoiumという文字列が含まれていません: `%s`", displayName) : "")).queue();
         channel.sendFile(file, hash + ".txt").queue();
     }
 


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

jaoiumではないjaoiumの場合、警告を挿入するように変更

## 関連する Issue

- close #346

## チェックリスト

> `[ ]` を `[x]` にすることでチェックできます

- [x] 【必須】[CONTRIBUTING](https://github.com/jaoafa/MyMaid4/blob/master/CONTRIBUTING.md) を読みました
- [x] 【必須】テストサーバで動作確認をしました
  - [x] ローカルサーバで動作確認しました
  - [ ] ZakuroHatのテストサーバで動作確認しました
- [x] 【必須】プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- [x] 【必須】`NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [x] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
  - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [ ] 複数のクラスにわたって使用される変数があるので、 `MyMaidData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `MyMaidLibrary` にその関数を作成し管理しています
