### PR TITLE
Kohonayoshi lead

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Lead.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Lead.java
@@ -57,11 +57,11 @@ public class Cmd_Lead extends MyMaidLibrary implements CommandPremise {
                 .handler(this::leadEntityToEntity)
                 .build(),
             builder
-                .meta(CommandMeta.DESCRIPTION, "[Mob（またはプレイヤー）]が付けられているか、持っているリードを外します。両方の場合は付けられているリードを優先します")
+                .meta(CommandMeta.DESCRIPTION, "[Mob（または実行者）]が付けられているか、持っているリードを外します。両方の場合は付けられているリードを優先します")
                 .senderType(Player.class)
                 .literal("leave")
                 .argument(SingleEntitySelectorArgument.optional("target"),
-                    ArgumentDescription.of("対象のMob（またはプレイヤー）。対象を指定しない場合見ているMob、何も見ていない場合実行者"))
+                    ArgumentDescription.of("対象のMob（または実行者）。対象を指定しない場合見ているMob、何も見ていない場合実行者"))
                 .handler(this::unLeadEntity)
                 .build()
         );
@@ -153,6 +153,9 @@ public class Cmd_Lead extends MyMaidLibrary implements CommandPremise {
             LivingEntity looking = null;
             for (Entity e : entities) {
                 if (!(e instanceof LivingEntity)) {
+                    continue;
+                }
+                if (e == player) {
                     continue;
                 }
                 if (isEntityLooking(player, (LivingEntity) e)) {

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Lead.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Lead.java
@@ -155,9 +155,6 @@ public class Cmd_Lead extends MyMaidLibrary implements CommandPremise {
                 if (!(e instanceof LivingEntity)) {
                     continue;
                 }
-                if (e == player) {
-                    continue;
-                }
                 if (isEntityLooking(player, (LivingEntity) e)) {
                     looking = (LivingEntity) e;
                     break;
@@ -167,6 +164,11 @@ public class Cmd_Lead extends MyMaidLibrary implements CommandPremise {
                 looking = player;
             }
             target = looking;
+        }
+
+        if (target instanceof Player && target != player) {
+            SendMessage(player, details(), "他のプレイヤーを対象にすることはできません。");
+            return;
         }
 
         if (target.setLeashHolder(null)) {


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

①対象のエンティティを見てlead leaveで外せるように
②lead leaveをリードを付けられている側だけでなくリードを持っている側からも外せるように
③どのエンティティも見ていない状態で lead leaveしたら自分が持っているリードを外せるように
④上記の追加により他プレイヤーをlead leaveできてしまう問題について、他プレイヤーを実行対象外にするように

## チェックリスト

> `[ ]` を `[x]` にすることでチェックできます

- [x] 【必須】[CONTRIBUTING](https://github.com/jaoafa/MyMaid4/blob/master/CONTRIBUTING.md) を読みました
- [x] 【必須】テストサーバで動作確認をしました
  - [x] ローカルサーバで動作確認しました
  - [x] ZakuroHatのテストサーバで動作確認しました
- [x] 【必須】プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- [ ] 【必須】`NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [ ] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
  - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [ ] 複数のクラスにわたって使用される変数があるので、 `MyMaidData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `MyMaidLibrary` にその関数を作成し管理しています
