### PR TITLE
Leadunit

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_wire.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_wire.java
@@ -79,9 +79,9 @@ public class Cmd_wire extends MyMaidLibrary implements CommandPremise {
             builder
                 .meta(CommandMeta.DESCRIPTION, "WorldEditで選択した2点間にリードを張ります。1座標目がリードを付けられている側、2座標目がリードを持っている側。")
                 .senderType(Player.class)
-                .literal("setwe", "we", "weset")
+                .literal("setwe", "addwe", "connectwe", "we")
                 .handler(this::setWireWe)
-//                .build(),
+                .build(),
 //
 //            builder
 //                .meta(CommandMeta.DESCRIPTION, "指定した2点間のリードを撤去します。座標を指定しない場合、WorldEditで選択した2点間のリードを撤去します。")
@@ -92,15 +92,12 @@ public class Cmd_wire extends MyMaidLibrary implements CommandPremise {
 //                    ArgumentDescription.of("リードを付けられる側のMob"))
 //                .handler(this::delWire)
 //                .build(),
-
-//            builder
-//                .meta(CommandMeta.DESCRIPTION, "指定した2点間のリードを撤去します。座標を指定しない場合、WorldEditで選択した2点間のリードを撤去します。")
-//                .literal("del", "delete", "remove")
-//                .argument(SingleEntitySelectorArgument.of("from"),
-//                    ArgumentDescription.of("リードを持っている側のMob（またはプレイヤー）"))
-//                .argument(SingleEntitySelectorArgument.of("to"),
-//                    ArgumentDescription.of("リードを付けられる側のMob"))
-//                .handler(this::delWireWe)
+//
+            builder
+                .meta(CommandMeta.DESCRIPTION, "WorldEditで選択した2点間にリードを張ります。1座標目がリードを付けられている側、2座標目がリードを持っている側。")
+                .senderType(Player.class)
+                .literal("delwe", "deletewe", "removewe")
+                .handler(this::delWireWe)
 //                .build(),
 //
 //            builder
@@ -152,6 +149,33 @@ public class Cmd_wire extends MyMaidLibrary implements CommandPremise {
         }
     }
 
+    void delWireWe(CommandContext<CommandSender> context) {
+        Player player = (Player) context.getSender();
+
+        WorldEditPlugin we = getWorldEdit();
+
+        if (we == null) {
+            SendMessage(player, details(), "WorldEditと連携できないため、このコマンドを使用できません。");
+            return;
+        }
+
+        try {
+            World selectionWorld = we.getSession(player).getSelectionWorld();
+            CuboidRegion cuboidRegion = (CuboidRegion) we.getSession(player).getSelection(selectionWorld);
+
+            BlockVector3 locationArgumentWePos1 = cuboidRegion.getPos1();
+            BlockVector3 locationArgumentWePos2 = cuboidRegion.getPos2();
+            Location loc1 = new Location(player.getWorld(), locationArgumentWePos1.getX() + 0.5, locationArgumentWePos1.getY(), locationArgumentWePos1.getZ() + 0.5);
+            Location loc2 = new Location(player.getWorld(), locationArgumentWePos2.getX() + 0.5, locationArgumentWePos2.getY(), locationArgumentWePos2.getZ() + 0.5);
+
+            summonBat(player, loc1, loc2);
+
+        } catch (IncompleteRegionException e) {
+            SendMessage(player, details(), "WorldEditで範囲を指定してください。");
+
+        }
+    }
+
     void delWireUnit(CommandContext<CommandSender> context) {
         CommandSender sender = context.getSender();
         SendMessage(sender, details(), "このコマンドは未実装です。");
@@ -163,10 +187,10 @@ public class Cmd_wire extends MyMaidLibrary implements CommandPremise {
             batnbt1.setAI(false);
             batnbt1.setAwake(true);
             batnbt1.setSilent(true);
-            batnbt1.setPersistent(true);
             batnbt1.setInvulnerable(true);
+            batnbt1.setRemoveWhenFarAway(false);
             batnbt1.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 1, true, false, true));
-//            batnbt1.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, Integer.MAX_VALUE, 1, true, false, true)); //確認用
+            batnbt1.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, Integer.MAX_VALUE, 1, true, false, true)); //確認用
             batnbt1.addScoreboardTag("wireUnit");
         });
 
@@ -174,10 +198,10 @@ public class Cmd_wire extends MyMaidLibrary implements CommandPremise {
             batnbt2.setAI(false);
             batnbt2.setAwake(true);
             batnbt2.setSilent(true);
-            batnbt2.setPersistent(true);
             batnbt2.setInvulnerable(true);
+            batnbt2.setRemoveWhenFarAway(false);
             batnbt2.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 1, true, false, true));
-//            batnbt2.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, Integer.MAX_VALUE, 1, true, false, true)); //確認用
+            batnbt2.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, Integer.MAX_VALUE, 1, true, false, true)); //確認用
             batnbt2.addScoreboardTag("wireUnit");
         });
 

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_wire.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_wire.java
@@ -81,7 +81,7 @@ public class Cmd_wire extends MyMaidLibrary implements CommandPremise {
                 .senderType(Player.class)
                 .literal("setwe", "addwe", "connectwe", "we")
                 .handler(this::setWireWe)
-                .build(),
+//                .build(),
 //
 //            builder
 //                .meta(CommandMeta.DESCRIPTION, "指定した2点間のリードを撤去します。座標を指定しない場合、WorldEditで選択した2点間のリードを撤去します。")
@@ -93,11 +93,11 @@ public class Cmd_wire extends MyMaidLibrary implements CommandPremise {
 //                .handler(this::delWire)
 //                .build(),
 //
-            builder
-                .meta(CommandMeta.DESCRIPTION, "WorldEditで選択した2点間にリードを張ります。1座標目がリードを付けられている側、2座標目がリードを持っている側。")
-                .senderType(Player.class)
-                .literal("delwe", "deletewe", "removewe")
-                .handler(this::delWireWe)
+//            builder
+//                .meta(CommandMeta.DESCRIPTION, "WorldEditで選択した2点間にリードを張ります。1座標目がリードを付けられている側、2座標目がリードを持っている側。")
+//                .senderType(Player.class)
+//                .literal("delwe", "deletewe", "removewe")
+//                .handler(this::delWireWe)
 //                .build(),
 //
 //            builder
@@ -149,32 +149,32 @@ public class Cmd_wire extends MyMaidLibrary implements CommandPremise {
         }
     }
 
-    void delWireWe(CommandContext<CommandSender> context) {
-        Player player = (Player) context.getSender();
-
-        WorldEditPlugin we = getWorldEdit();
-
-        if (we == null) {
-            SendMessage(player, details(), "WorldEditと連携できないため、このコマンドを使用できません。");
-            return;
-        }
-
-        try {
-            World selectionWorld = we.getSession(player).getSelectionWorld();
-            CuboidRegion cuboidRegion = (CuboidRegion) we.getSession(player).getSelection(selectionWorld);
-
-            BlockVector3 locationArgumentWePos1 = cuboidRegion.getPos1();
-            BlockVector3 locationArgumentWePos2 = cuboidRegion.getPos2();
-            Location loc1 = new Location(player.getWorld(), locationArgumentWePos1.getX() + 0.5, locationArgumentWePos1.getY(), locationArgumentWePos1.getZ() + 0.5);
-            Location loc2 = new Location(player.getWorld(), locationArgumentWePos2.getX() + 0.5, locationArgumentWePos2.getY(), locationArgumentWePos2.getZ() + 0.5);
-
-            summonBat(player, loc1, loc2);
-
-        } catch (IncompleteRegionException e) {
-            SendMessage(player, details(), "WorldEditで範囲を指定してください。");
-
-        }
-    }
+//    void delWireWe(CommandContext<CommandSender> context) {
+//        Player player = (Player) context.getSender();
+//
+//        WorldEditPlugin we = getWorldEdit();
+//
+//        if (we == null) {
+//            SendMessage(player, details(), "WorldEditと連携できないため、このコマンドを使用できません。");
+//            return;
+//        }
+//
+//        try {
+//            World selectionWorld = we.getSession(player).getSelectionWorld();
+//            CuboidRegion cuboidRegion = (CuboidRegion) we.getSession(player).getSelection(selectionWorld);
+//
+//            BlockVector3 locationArgumentWePos1 = cuboidRegion.getPos1();
+//            BlockVector3 locationArgumentWePos2 = cuboidRegion.getPos2();
+//            Location loc1 = new Location(player.getWorld(), locationArgumentWePos1.getX() + 0.5, locationArgumentWePos1.getY(), locationArgumentWePos1.getZ() + 0.5);
+//            Location loc2 = new Location(player.getWorld(), locationArgumentWePos2.getX() + 0.5, locationArgumentWePos2.getY(), locationArgumentWePos2.getZ() + 0.5);
+//
+//            summonBat(player, loc1, loc2);
+//
+//        } catch (IncompleteRegionException e) {
+//            SendMessage(player, details(), "WorldEditで範囲を指定してください。");
+//
+//        }
+//    }
 
     void delWireUnit(CommandContext<CommandSender> context) {
         CommandSender sender = context.getSender();


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

> どのような機能・コマンドを実装したり、修正したかを簡潔に説明してください

プレイヤーが離れた時にリードのコウモリがデスポーンする致命的なバグ


## 関連する Issue

> 関連する Issue がある場合は、`#1` のような形式で示してください
> マージと同時にクローズされる必要がある場合は、`close #1` のように記載してください

close #410

## チェックリスト

> `[ ]` を `[x]` にすることでチェックできます

- [x] 【必須】[CONTRIBUTING](https://github.com/jaoafa/MyMaid4/blob/master/CONTRIBUTING.md) を読みました
- [x] 【必須】テストサーバで動作確認をしました
  - [x] ローカルサーバで動作確認しました
  - [ ] ZakuroHatのテストサーバで動作確認しました
- [x] 【必須】プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- [x] 【必須】`NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [ ] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
  - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [ ] 複数のクラスにわたって使用される変数があるので、 `MyMaidData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `MyMaidLibrary` にその関数を作成し管理しています

## 追加情報

> 何か追加情報がある場合は記載してください


