### PR TITLE
fix: #263 coコマンドなどにおいて、引数なしだとエラーになる不具合

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/event/Event_ManageCPPerms.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_ManageCPPerms.java
@@ -78,6 +78,9 @@ public class Event_ManageCPPerms extends MyMaidLibrary implements Listener, Even
             !args[0].equalsIgnoreCase("/co")) {
             return;
         }
+        if (args.length == 1) {
+            return;
+        }
 
         Optional<Map.Entry<String, String>> func = cpSubCommands.entrySet().stream()
             .filter(cmd -> cmd.getKey().equalsIgnoreCase(args[1]))


### PR DESCRIPTION
close #263 