### PR TITLE
chore: 引数の説明追加・その他

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Brb.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Brb.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.bukkit.parsers.PlayerArgument;
 import cloud.commandframework.context.CommandContext;
@@ -43,7 +44,7 @@ public class Cmd_Brb extends MyMaidLibrary implements CommandPremise {
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "バリアブロックを指定したプレイヤーのメインハンドのアイテムと置き換えます。")
-                .argument(PlayerArgument.of("player"))
+                .argument(PlayerArgument.of("player"), ArgumentDescription.of("バリアブロックを付与するプレイヤー名"))
                 .handler(this::giveBarrierToPlayer)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Bug.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Bug.java
@@ -66,15 +66,15 @@ public class Cmd_Bug extends MyMaidLibrary implements CommandPremise {
                 .meta(CommandMeta.DESCRIPTION, "本によりIssue作成処理を行います。")
                 .senderType(Player.class)
                 .literal("true")
-                .hidden()
                 .handler(this::createIssueBook)
+                .hidden()
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "記入済みの本を記入可能な本に戻します。")
                 .senderType(Player.class)
                 .literal("false")
-                .hidden()
                 .handler(this::reWritableBook)
+                .hidden()
                 .build()
         );
     }
@@ -83,7 +83,7 @@ public class Cmd_Bug extends MyMaidLibrary implements CommandPremise {
         Player player = (Player) context.getSender();
         PlayerInventory inv = player.getInventory();
 
-        if (Main.getMyMaidConfig().getGithubAccessToken() == null) {
+        if (Main.getMyMaidConfig().getGitHubAccessToken() == null) {
             SendMessage(player, details(), "不具合報告に必要な設定情報が見つからなかったため、不具合報告ができません。");
             return;
         }
@@ -196,7 +196,7 @@ public class Cmd_Bug extends MyMaidLibrary implements CommandPremise {
 
         new BukkitRunnable() {
             public void run() {
-                String accessToken = Main.getMyMaidConfig().getGithubAccessToken();
+                String accessToken = Main.getMyMaidConfig().getGitHubAccessToken();
                 if (accessToken == null) {
                     SendMessage(player, details(), "不具合報告に必要な設定情報が見つからなかったため、不具合報告ができませんでした。");
                     return;

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Chat.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Chat.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.context.CommandContext;
@@ -42,8 +43,8 @@ public class Cmd_Chat extends MyMaidLibrary implements CommandPremise {
         return new MyMaidCommand.Cmd(
             builder
                 .meta(CommandMeta.DESCRIPTION, "偽のプレイヤーに喋らせます。")
-                .argument(StringArgument.single("player"))
-                .argument(StringArgument.greedy("message"))
+                .argument(StringArgument.single("player"), ArgumentDescription.of("喋らせるプレイヤー名"))
+                .argument(StringArgument.greedy("message"), ArgumentDescription.of("喋らせるメッセージ"))
                 .handler(this::chatFake)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_ChatBan.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_ChatBan.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.bukkit.parsers.OfflinePlayerArgument;
@@ -44,22 +45,22 @@ public class Cmd_ChatBan extends MyMaidLibrary implements CommandPremise {
             builder
                 .meta(CommandMeta.DESCRIPTION, "ターゲットをChatBanします。")
                 .literal("add")
-                .argument(OfflinePlayerArgument.of("player"))
-                .argument(StringArgument.greedy("reason"))
+                .argument(OfflinePlayerArgument.of("player"), ArgumentDescription.of("対象のプレイヤー"))
+                .argument(StringArgument.greedy("reason"), ArgumentDescription.of("理由"))
                 .handler(this::addChatBan)
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "ターゲットのChatBanを解除します。")
                 .literal("remove", "del", "rem")
-                .argument(OfflinePlayerArgument.of("player"))
+                .argument(OfflinePlayerArgument.of("player"), ArgumentDescription.of("対象のプレイヤー"))
                 .handler(this::removeChatBan)
                 .build(),
             builder
-                .meta(CommandMeta.DESCRIPTION, "ChatBan一覧を表示します。")
+                .meta(CommandMeta.DESCRIPTION, "ChatBan一覧もしくは詳細を表示します。")
                 .literal("status", "list")
                 .argument(OfflinePlayerArgument
                     .<CommandSender>newBuilder("player")
-                    .asOptional())
+                    .asOptional(), ArgumentDescription.of("詳細を表示するプレイヤー名"))
                 .handler(this::getStatus)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_ChatBan.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_ChatBan.java
@@ -60,7 +60,7 @@ public class Cmd_ChatBan extends MyMaidLibrary implements CommandPremise {
                 .literal("status", "list")
                 .argument(OfflinePlayerArgument
                     .<CommandSender>newBuilder("player")
-                    .asOptional(), ArgumentDescription.of("詳細を表示するプレイヤー名"))
+                    .asOptional(), ArgumentDescription.of("詳細を表示するプレイヤー"))
                 .handler(this::getStatus)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Cmdb.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Cmdb.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.bukkit.parsers.PlayerArgument;
 import cloud.commandframework.context.CommandContext;
@@ -43,7 +44,7 @@ public class Cmd_Cmdb extends MyMaidLibrary implements CommandPremise {
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "コマンドブロックを指定したプレイヤーのメインハンドのアイテムと置き換えます。")
-                .argument(PlayerArgument.of("player"))
+                .argument(PlayerArgument.of("player"), ArgumentDescription.of("コマンドブロックを付与するプレイヤー名"))
                 .handler(this::giveCommandBlockToPlayer)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_DT.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_DT.java
@@ -16,7 +16,7 @@ import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.IntegerArgument;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.bukkit.arguments.selector.MultipleEntitySelector;
-import cloud.commandframework.bukkit.parsers.selector.MultiplePlayerSelectorArgument;
+import cloud.commandframework.bukkit.parsers.selector.MultipleEntitySelectorArgument;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.meta.CommandMeta;
 import com.jaoafa.mymaid4.lib.CommandPremise;
@@ -67,9 +67,9 @@ public class Cmd_DT extends MyMaidLibrary implements CommandPremise {
                 .handler(this::teleportMarker)
                 .build(),
             builder
-                .meta(CommandMeta.DESCRIPTION, "プレイヤーをマーカーにテレポートさせます。")
+                .meta(CommandMeta.DESCRIPTION, "エンティティをマーカーにテレポートさせます。")
                 .literal("tp")
-                .argument(MultiplePlayerSelectorArgument
+                .argument(MultipleEntitySelectorArgument
                     .newBuilder("targets"), ArgumentDescription.of("エンティティ対象セレクター"))
                 .argument(StringArgument
                     .newBuilder("markerName"), ArgumentDescription.of("マーカー名"))

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Debstick.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Debstick.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.bukkit.parsers.PlayerArgument;
 import cloud.commandframework.context.CommandContext;
@@ -43,7 +44,7 @@ public class Cmd_Debstick extends MyMaidLibrary implements CommandPremise {
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "デバッグステイックを指定したプレイヤーのメインハンドのアイテムと置き換えます。")
-                .argument(PlayerArgument.of("player"))
+                .argument(PlayerArgument.of("player"), ArgumentDescription.of("デバッグスティックを付与するプレイヤー"))
                 .handler(this::giveCommandBlockToPlayer)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_DedMessage.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_DedMessage.java
@@ -77,7 +77,7 @@ public class Cmd_DedMessage extends MyMaidLibrary implements CommandPremise {
                 .literal("remove")
                 .argument(IntegerArgument
                     .<CommandSender>newBuilder("id")
-                    .withSuggestionsProvider(this::suggestCustomDedMessageIds))
+                    .withSuggestionsProvider(this::suggestCustomDedMessageIds), ArgumentDescription.of("カスタム死亡メッセージID"))
                 .handler(this::removeCustomDeathMessage)
                 .build(),
             builder
@@ -87,7 +87,7 @@ public class Cmd_DedMessage extends MyMaidLibrary implements CommandPremise {
                 .argument(IntegerArgument
                     .<CommandSender>newBuilder("page")
                     .withMin(1)
-                    .asOptionalWithDefault("1"))
+                    .asOptionalWithDefault("1"), ArgumentDescription.of("カスタム死亡メッセージID"))
                 .handler(this::listCustomDeathMessage)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_DelHome.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_DelHome.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.context.CommandContext;
@@ -55,7 +56,7 @@ public class Cmd_DelHome extends MyMaidLibrary implements CommandPremise {
                 .argument(StringArgument
                     .<CommandSender>newBuilder("name")
                     .asOptionalWithDefault("default")
-                    .withSuggestionsProvider(Home::suggestHomeName))
+                    .withSuggestionsProvider(Home::suggestHomeName), ArgumentDescription.of("ホーム名"))
                 .handler(this::deleteHome)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_DiscordLink.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_DiscordLink.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.context.CommandContext;
@@ -50,8 +51,7 @@ public class Cmd_DiscordLink extends MyMaidLibrary implements CommandPremise {
             builder
                 .meta(CommandMeta.DESCRIPTION, "DiscordアカウントとMinecraftアカウントを紐づけます。")
                 .senderType(Player.class)
-                .argument(StringArgument
-                    .newBuilder("authKey"))
+                .argument(StringArgument.of("authKey"), ArgumentDescription.of("認証コード"))
                 .handler(this::authDiscord)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_EBan.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_EBan.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.bukkit.parsers.OfflinePlayerArgument;
@@ -44,14 +45,14 @@ public class Cmd_EBan extends MyMaidLibrary implements CommandPremise {
             builder
                 .meta(CommandMeta.DESCRIPTION, "ターゲットをEBanします。")
                 .literal("add")
-                .argument(OfflinePlayerArgument.of("player"))
-                .argument(StringArgument.greedy("reason"))
+                .argument(OfflinePlayerArgument.of("player"), ArgumentDescription.of("プレイヤー名"))
+                .argument(StringArgument.greedy("reason"), ArgumentDescription.of("理由"))
                 .handler(this::addEBan)
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "ターゲットのEBanを解除します。")
                 .literal("remove", "del", "rem")
-                .argument(OfflinePlayerArgument.of("player"))
+                .argument(OfflinePlayerArgument.of("player"), ArgumentDescription.of("対象のプレイヤー名"))
                 .handler(this::removeEBan)
                 .build(),
             builder

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_EBan.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_EBan.java
@@ -45,14 +45,14 @@ public class Cmd_EBan extends MyMaidLibrary implements CommandPremise {
             builder
                 .meta(CommandMeta.DESCRIPTION, "ターゲットをEBanします。")
                 .literal("add")
-                .argument(OfflinePlayerArgument.of("player"), ArgumentDescription.of("プレイヤー名"))
+                .argument(OfflinePlayerArgument.of("player"), ArgumentDescription.of("対象のプレイヤー"))
                 .argument(StringArgument.greedy("reason"), ArgumentDescription.of("理由"))
                 .handler(this::addEBan)
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "ターゲットのEBanを解除します。")
                 .literal("remove", "del", "rem")
-                .argument(OfflinePlayerArgument.of("player"), ArgumentDescription.of("対象のプレイヤー名"))
+                .argument(OfflinePlayerArgument.of("player"), ArgumentDescription.of("対象のプレイヤー"))
                 .handler(this::removeEBan)
                 .build(),
             builder

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_FlySpeed.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_FlySpeed.java
@@ -40,16 +40,14 @@ public class Cmd_FlySpeed extends MyMaidLibrary implements CommandPremise {
         return new MyMaidCommand.Cmd(
             builder
                 .meta(CommandMeta.DESCRIPTION, "指定したプレイヤーのクリエイティブ飛行速度を表示します。")
-                .argument(PlayerArgument.optional("target"),
-                    ArgumentDescription.of("ターゲットプレイヤー"))
+                .argument(PlayerArgument.optional("target"), ArgumentDescription.of("ターゲットプレイヤー"))
                 .handler(this::showFlySpeed)
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "クリエイティブ飛行速度を設定します。")
                 .senderType(Player.class)
                 .literal("set")
-                .argument(FloatArgument.of("percent"),
-                    ArgumentDescription.of("クリエイティブ飛行速度(通常100%)"))
+                .argument(FloatArgument.of("percent"), ArgumentDescription.of("クリエイティブ飛行速度(通常100%)"))
                 .handler(this::setFlySpeed)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_G.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_G.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.bukkit.parsers.PlayerArgument;
@@ -60,7 +61,7 @@ public class Cmd_G extends MyMaidLibrary implements CommandPremise {
                 .senderType(Player.class)
                 .argument(StringArgument
                     .<CommandSender>newBuilder("gamemode")
-                    .withSuggestionsProvider(this::suggestGameMode))
+                    .withSuggestionsProvider(this::suggestGameMode), ArgumentDescription.of("ゲームモード"))
                 .handler(this::changeGamemode)
                 .build(),
             builder
@@ -68,7 +69,7 @@ public class Cmd_G extends MyMaidLibrary implements CommandPremise {
                 .argument(StringArgument
                     .<CommandSender>newBuilder("gamemode")
                     .withSuggestionsProvider(this::suggestGameMode))
-                .argument(PlayerArgument.of("player"))
+                .argument(PlayerArgument.of("player"), ArgumentDescription.of("ゲームモード"))
                 .handler(this::changePlayerGamemode)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Glookup.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Glookup.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.bukkit.parsers.PlayerArgument;
 import cloud.commandframework.context.CommandContext;
@@ -35,7 +36,7 @@ public class Cmd_Glookup extends MyMaidLibrary implements CommandPremise {
         return new MyMaidCommand.Cmd(
             builder
                 .meta(CommandMeta.DESCRIPTION, "他人のゲームモードを確認します。")
-                .argument(PlayerArgument.of("player"))
+                .argument(PlayerArgument.of("player"), ArgumentDescription.of("プレイヤー名"))
                 .handler(this::playerGamemodeLookup)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Head.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Head.java
@@ -11,22 +11,21 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
-import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.bukkit.parsers.OfflinePlayerArgument;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.meta.CommandMeta;
 import com.jaoafa.mymaid4.lib.CommandPremise;
 import com.jaoafa.mymaid4.lib.MyMaidCommand;
 import com.jaoafa.mymaid4.lib.MyMaidLibrary;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.SkullMeta;
-
-import java.util.Objects;
 
 public class Cmd_Head extends MyMaidLibrary implements CommandPremise {
     @Override
@@ -46,8 +45,8 @@ public class Cmd_Head extends MyMaidLibrary implements CommandPremise {
                 .handler(this::giveMyHead)
                 .build(),
             builder
-                .meta(CommandMeta.DESCRIPTION, "指定したプレイヤーの頭ブロックを入手します。" )
-                .argument(StringArgument.newBuilder("player" ))
+                .meta(CommandMeta.DESCRIPTION, "指定したプレイヤーの頭ブロックを入手します。")
+                .argument(OfflinePlayerArgument.of("player"), ArgumentDescription.of("対象のプレイヤー"))
                 .handler(this::givePlayerHead)
                 .build()
         );
@@ -78,11 +77,10 @@ public class Cmd_Head extends MyMaidLibrary implements CommandPremise {
 
     void givePlayerHead(CommandContext<CommandSender> context) {
         Player player = (Player) context.getSender();
-        String targetPlayer = context.getOrDefault("player", null);
+        OfflinePlayer targetPlayer = context.getOrDefault("player", null);
         ItemStack skull = new ItemStack(Material.PLAYER_HEAD);
         SkullMeta meta = (SkullMeta) skull.getItemMeta();
-        //noinspection deprecation プレイヤー名からOfflinePlayerを得るにはこの方法しかないため
-        meta.setOwningPlayer(Bukkit.getOfflinePlayer(Objects.requireNonNull(targetPlayer)));
+        meta.setOwningPlayer(targetPlayer);
         skull.setItemMeta(meta);
         PlayerInventory inv = player.getInventory();
         ItemStack main = inv.getItemInMainHand();

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Hide.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Hide.java
@@ -12,6 +12,7 @@
 package com.jaoafa.mymaid4.command;
 
 import cloud.commandframework.Command;
+import cloud.commandframework.bukkit.parsers.PlayerArgument;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.meta.CommandMeta;
 import com.jaoafa.mymaid4.Main;
@@ -39,6 +40,12 @@ public class Cmd_Hide extends MyMaidLibrary implements CommandPremise {
                 .meta(CommandMeta.DESCRIPTION, "他のプレイヤーから姿を隠します。")
                 .senderType(Player.class)
                 .handler(this::addHid)
+                .build(),
+            builder
+                .meta(CommandMeta.DESCRIPTION, "指定したプレイヤーを他のプレイヤーから姿を隠します。")
+                .senderType(Player.class)
+                .argument(PlayerArgument.of("target"))
+                .handler(this::addHidOther)
                 .build()
         );
     }
@@ -58,5 +65,28 @@ public class Cmd_Hide extends MyMaidLibrary implements CommandPremise {
         }
         SendMessage(player, details(), "あなたは他のプレイヤーから見えなくなりました。見えるようにするには/showを実行しましょう。");
         SendMessage(player, details(), "なお、プレイヤーリストからも見えなくなりますのでお気をつけて。");
+    }
+
+    void addHidOther(CommandContext<CommandSender> context) {
+        Player player = (Player) context.getSender();
+        Player target = context.get("target");
+        if (!isAMR(player)) {
+            SendMessage(player, details(), "あなたの権限ではこのコマンドを実行することができません！");
+            return;
+        }
+        if (!isAMR(target)) {
+            SendMessage(player, details(), "対象のプレイヤーの権限がRegular以上でないため、実行できません。");
+            return;
+        }
+
+        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+            p.hidePlayer(Main.getJavaPlugin(), target);
+        }
+        if (!MyMaidData.isHid(target.getUniqueId())) {
+            MyMaidData.addHid(target.getUniqueId());
+        }
+        SendMessage(target, details(), "あなたは他のプレイヤーから見えなくなりました。見えるようにするには/showを実行しましょう。");
+        SendMessage(target, details(), "なお、プレイヤーリストからも見えなくなりますのでお気をつけて。");
+        SendMessage(player, details(), "プレイヤー「" + target.getName() + "」を他のプレイヤーから見えなくしました。");
     }
 }

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Hide.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Hide.java
@@ -12,7 +12,6 @@
 package com.jaoafa.mymaid4.command;
 
 import cloud.commandframework.Command;
-import cloud.commandframework.bukkit.parsers.PlayerArgument;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.meta.CommandMeta;
 import com.jaoafa.mymaid4.Main;
@@ -40,12 +39,6 @@ public class Cmd_Hide extends MyMaidLibrary implements CommandPremise {
                 .meta(CommandMeta.DESCRIPTION, "他のプレイヤーから姿を隠します。")
                 .senderType(Player.class)
                 .handler(this::addHid)
-                .build(),
-            builder
-                .meta(CommandMeta.DESCRIPTION, "指定したプレイヤーを他のプレイヤーから姿を隠します。")
-                .senderType(Player.class)
-                .argument(PlayerArgument.of("target"))
-                .handler(this::addHidOther)
                 .build()
         );
     }
@@ -65,28 +58,5 @@ public class Cmd_Hide extends MyMaidLibrary implements CommandPremise {
         }
         SendMessage(player, details(), "あなたは他のプレイヤーから見えなくなりました。見えるようにするには/showを実行しましょう。");
         SendMessage(player, details(), "なお、プレイヤーリストからも見えなくなりますのでお気をつけて。");
-    }
-
-    void addHidOther(CommandContext<CommandSender> context) {
-        Player player = (Player) context.getSender();
-        Player target = context.get("target");
-        if (!isAMR(player)) {
-            SendMessage(player, details(), "あなたの権限ではこのコマンドを実行することができません！");
-            return;
-        }
-        if (!isAMR(target)) {
-            SendMessage(player, details(), "対象のプレイヤーの権限がRegular以上でないため、実行できません。");
-            return;
-        }
-
-        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
-            p.hidePlayer(Main.getJavaPlugin(), target);
-        }
-        if (!MyMaidData.isHid(target.getUniqueId())) {
-            MyMaidData.addHid(target.getUniqueId());
-        }
-        SendMessage(target, details(), "あなたは他のプレイヤーから見えなくなりました。見えるようにするには/showを実行しましょう。");
-        SendMessage(target, details(), "なお、プレイヤーリストからも見えなくなりますのでお気をつけて。");
-        SendMessage(player, details(), "プレイヤー「" + target.getName() + "」を他のプレイヤーから見えなくしました。");
     }
 }

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Hide.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Hide.java
@@ -43,7 +43,6 @@ public class Cmd_Hide extends MyMaidLibrary implements CommandPremise {
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "指定したプレイヤーを他のプレイヤーから姿を隠します。")
-                .senderType(Player.class)
                 .argument(PlayerArgument.of("target"))
                 .handler(this::addHidOther)
                 .build()

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_History.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_History.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.BooleanArgument;
 import cloud.commandframework.arguments.standard.IntegerArgument;
@@ -47,28 +48,28 @@ public class Cmd_History extends MyMaidLibrary implements CommandPremise {
             builder
                 .meta(CommandMeta.DESCRIPTION, "指定したプレイヤーのjaoHistoryにデータを追加します。")
                 .literal("add")
-                .argument(OfflinePlayerArgument.of("target"))
-                .argument(StringArgument.greedy("message"))
+                .argument(OfflinePlayerArgument.of("target"), ArgumentDescription.of("対象のプレイヤー"))
+                .argument(StringArgument.greedy("message"), ArgumentDescription.of("メッセージ"))
                 .handler(this::addItem)
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "指定したプレイヤーのjaoHistory項目を無効化します。")
                 .literal("disable")
-                .argument(OfflinePlayerArgument.of("target"))
+                .argument(OfflinePlayerArgument.of("target"), ArgumentDescription.of("対象のプレイヤー"))
                 .argument(IntegerArgument.<CommandSender>newBuilder("item")
-                    .withSuggestionsProvider(this::suggestHistoryIds))
+                    .withSuggestionsProvider(this::suggestHistoryIds), ArgumentDescription.of("jaoHistoryId"))
                 .handler(this::disableItem)
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "指定したプレイヤーのjaoHistory項目の通知設定を行います。")
                 .literal("notify")
-                .argument(OfflinePlayerArgument.of("target"))
+                .argument(OfflinePlayerArgument.of("target"), ArgumentDescription.of("対象のプレイヤー"))
                 .argument(IntegerArgument.<CommandSender>newBuilder("item")
-                    .withSuggestionsProvider(this::suggestHistoryIds))
+                    .withSuggestionsProvider(this::suggestHistoryIds), ArgumentDescription.of("jaoHistoryId"))
                 .argument(BooleanArgument
                     .<CommandSender>newBuilder("changeTo")
                     .withLiberal(true)
-                    .withSuggestionsProvider(this::suggestBoolean))
+                    .withSuggestionsProvider(this::suggestBoolean), ArgumentDescription.of("変更後の通知設定"))
                 .handler(this::notifyItem)
                 .build(),
             builder

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Home.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Home.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.IntegerArgument;
 import cloud.commandframework.arguments.standard.StringArgument;
@@ -53,7 +54,7 @@ public class Cmd_Home extends MyMaidLibrary implements CommandPremise {
                 .argument(StringArgument
                     .<CommandSender>newBuilder("name")
                     .asOptionalWithDefault("default")
-                    .withSuggestionsProvider(Home::suggestHomeName))
+                    .withSuggestionsProvider(Home::suggestHomeName), ArgumentDescription.of("ページ"))
                 .handler(this::teleportHome)
                 .build(),
             builder
@@ -63,7 +64,7 @@ public class Cmd_Home extends MyMaidLibrary implements CommandPremise {
                 .handler(this::listHome)
                 .argument(IntegerArgument
                     .<CommandSender>newBuilder("Page").withMin(1)
-                    .asOptionalWithDefault("1"))
+                    .asOptionalWithDefault("1"), ArgumentDescription.of("ページ"))
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "指定したホームに関する情報を表示します。")
@@ -72,7 +73,7 @@ public class Cmd_Home extends MyMaidLibrary implements CommandPremise {
                 .argument(StringArgument
                     .<CommandSender>newBuilder("name")
                     .asOptionalWithDefault("default")
-                    .withSuggestionsProvider(Home::suggestHomeName))
+                    .withSuggestionsProvider(Home::suggestHomeName), ArgumentDescription.of("ページ"))
                 .handler(this::viewHome)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_InvLoad.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_InvLoad.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.bukkit.arguments.selector.SinglePlayerSelector;
@@ -44,9 +45,9 @@ public class Cmd_InvLoad extends MyMaidLibrary implements CommandPremise {
         return new MyMaidCommand.Cmd(
             builder
                 .meta(CommandMeta.DESCRIPTION, "指定したプレイヤーにおける指定した名前のインベントリを復元します。")
-                .argument(SinglePlayerSelectorArgument.of("target"))
-                .argument(StringArgument.optional("saveName"))
-                .argument(SinglePlayerSelectorArgument.optional("player"))
+                .argument(SinglePlayerSelectorArgument.of("target"), ArgumentDescription.of("インベントリを保存したプレイヤー"))
+                .argument(StringArgument.optional("saveName"), ArgumentDescription.of("保存名"))
+                .argument(SinglePlayerSelectorArgument.optional("player"), ArgumentDescription.of("復元先のプレイヤー"))
                 .handler(this::loadInventory)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_InvSave.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_InvSave.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.bukkit.arguments.selector.SinglePlayerSelector;
@@ -43,8 +44,8 @@ public class Cmd_InvSave extends MyMaidLibrary implements CommandPremise {
         return new MyMaidCommand.Cmd(
             builder
                 .meta(CommandMeta.DESCRIPTION, "指定したプレイヤーのインベントリを指定した名前で保存します。")
-                .argument(SinglePlayerSelectorArgument.of("target"))
-                .argument(StringArgument.optional("saveName"))
+                .argument(SinglePlayerSelectorArgument.of("target"), ArgumentDescription.of("インベントリを保存するプレイヤー"))
+                .argument(StringArgument.optional("saveName"), ArgumentDescription.of("保存名"))
                 .handler(this::saveInventory)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Jail.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Jail.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.bukkit.parsers.OfflinePlayerArgument;
@@ -44,14 +45,14 @@ public class Cmd_Jail extends MyMaidLibrary implements CommandPremise {
             builder
                 .meta(CommandMeta.DESCRIPTION, "ターゲットをJailします。")
                 .literal("add")
-                .argument(OfflinePlayerArgument.of("player"))
+                .argument(OfflinePlayerArgument.of("player"), ArgumentDescription.of("対象のプレイヤー"))
                 .argument(StringArgument.greedy("reason"))
                 .handler(this::addJail)
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "ターゲットのJailを解除します。")
                 .literal("remove", "del", "rem")
-                .argument(OfflinePlayerArgument.of("player"))
+                .argument(OfflinePlayerArgument.of("player"), ArgumentDescription.of("対象のプレイヤー"))
                 .handler(this::removeJail)
                 .build(),
             builder
@@ -59,14 +60,14 @@ public class Cmd_Jail extends MyMaidLibrary implements CommandPremise {
                 .literal("status", "list")
                 .argument(OfflinePlayerArgument
                     .<CommandSender>newBuilder("player")
-                    .asOptional())
+                    .asOptional(), ArgumentDescription.of("詳細を表示するプレイヤー"))
                 .handler(this::getStatus)
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "遺言を記録します。")
                 .senderType(Player.class)
                 .literal("testment")
-                .argument(StringArgument.greedy("message"))
+                .argument(StringArgument.greedy("message"), ArgumentDescription.of("遺言"))
                 .handler(this::setTestment)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_LoginText.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_LoginText.java
@@ -11,11 +11,15 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.meta.CommandMeta;
-import com.jaoafa.mymaid4.lib.*;
+import com.jaoafa.mymaid4.lib.CommandPremise;
+import com.jaoafa.mymaid4.lib.MyMaidCommand;
+import com.jaoafa.mymaid4.lib.MyMaidLibrary;
+import com.jaoafa.mymaid4.lib.PlayerVoteDataMCJP;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -39,7 +43,7 @@ public class Cmd_LoginText extends MyMaidLibrary implements CommandPremise {
             builder
                 .meta(CommandMeta.DESCRIPTION, "ログイン時に表示されるテキストに任意のテキストを追加します。")
                 .senderType(Player.class)
-                .argument(StringArgument.greedy("loginText"))
+                .argument(StringArgument.greedy("loginText"), ArgumentDescription.of("変更後のログインテキスト"))
                 .handler(this::setLoginText)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Looking.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Looking.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.bukkit.parsers.PlayerArgument;
 import cloud.commandframework.context.CommandContext;
@@ -47,7 +48,7 @@ public class Cmd_Looking extends MyMaidLibrary implements CommandPremise {
                 .meta(CommandMeta.DESCRIPTION, "プレイヤーを見続けはじめます。")
                 .senderType(Player.class)
                 .literal("on", "see", "start")
-                .argument(PlayerArgument.newBuilder("target"))
+                .argument(PlayerArgument.of("target"), ArgumentDescription.of("見続けるプレイヤー"))
                 .handler(this::startLooking)
                 .build(),
             builder

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Pigeon.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Pigeon.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.IntegerArgument;
 import cloud.commandframework.arguments.standard.StringArgument;
@@ -45,14 +46,14 @@ public class Cmd_Pigeon extends MyMaidLibrary implements CommandPremise {
                 .meta(CommandMeta.DESCRIPTION, "伝書鳩ちゃんにスピーカーを追加してもらいます。")
                 .literal("speaker", "speakers")
                 .literal("add")
-                .argument(StringArgument.greedy("speaker"))
+                .argument(StringArgument.greedy("speaker"), ArgumentDescription.of("スピーカー名"))
                 .handler(this::addSpeaker)
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "伝書鳩ちゃんにメッセージを追加してもらいます。")
                 .literal("messages", "message", "msg")
                 .literal("add")
-                .argument(StringArgument.greedy("message"))
+                .argument(StringArgument.greedy("message"), ArgumentDescription.of("メッセージ内容"))
                 .handler(this::addMessage)
                 .build(),
             builder
@@ -62,7 +63,7 @@ public class Cmd_Pigeon extends MyMaidLibrary implements CommandPremise {
                 .argument(StringArgument
                     .<CommandSender>newBuilder("speaker")
                     .asOptional()
-                    .withSuggestionsProvider(this::suggestSpeakers))
+                    .withSuggestionsProvider(this::suggestSpeakers), ArgumentDescription.of("スピーカー名もしくはID"))
                 .handler(this::removeSpeaker)
                 .build(),
             builder
@@ -72,7 +73,7 @@ public class Cmd_Pigeon extends MyMaidLibrary implements CommandPremise {
                 .argument(StringArgument
                     .<CommandSender>newBuilder("message")
                     .asOptional()
-                    .withSuggestionsProvider(this::suggestMessages))
+                    .withSuggestionsProvider(this::suggestMessages), ArgumentDescription.of("メッセージ内容"))
                 .handler(this::removeMessage)
                 .build(),
             builder
@@ -93,7 +94,7 @@ public class Cmd_Pigeon extends MyMaidLibrary implements CommandPremise {
                 .argument(IntegerArgument
                     .<CommandSender>newBuilder("messageId")
                     .asOptional()
-                    .withSuggestionsProvider(this::suggestMessageIds))
+                    .withSuggestionsProvider(this::suggestMessageIds), ArgumentDescription.of("メッセージID"))
                 .handler(this::broadcast)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Player.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Player.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.context.CommandContext;
@@ -50,7 +51,7 @@ public class Cmd_Player extends MyMaidLibrary implements CommandPremise {
                 .meta(CommandMeta.DESCRIPTION, "指定されたプレイヤーの権限グループを表示します。")
                 .argument(StringArgument
                     .<CommandSender>newBuilder("player")
-                    .withSuggestionsProvider(this::suggestOfflinePlayers))
+                    .withSuggestionsProvider(this::suggestOfflinePlayers), ArgumentDescription.of("対象のプレイヤー"))
                 .handler(this::getPermGroup)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_SKKColor.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_SKKColor.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.context.CommandContext;
@@ -53,7 +54,7 @@ public class Cmd_SKKColor extends MyMaidLibrary implements CommandPremise {
                 .meta(CommandMeta.DESCRIPTION, "チャット欄に表示される四角の色を変更します。")
                 .senderType(Player.class)
                 .argument(StringArgument.<CommandSender>newBuilder("color")
-                    .withSuggestionsProvider(this::suggestColors))
+                    .withSuggestionsProvider(this::suggestColors), ArgumentDescription.of("変更後の四角色"))
                 .handler(this::setSKKColor)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_SetHome.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_SetHome.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.context.CommandContext;
@@ -56,7 +57,7 @@ public class Cmd_SetHome extends MyMaidLibrary implements CommandPremise {
                 .senderType(Player.class)
                 .argument(StringArgument
                     .<CommandSender>newBuilder("name")
-                    .asOptionalWithDefault("default"))
+                    .asOptionalWithDefault("default"), ArgumentDescription.of("ホーム名。指定しない場合default"))
                 .handler(this::setHome)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Show.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Show.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.bukkit.parsers.PlayerArgument;
 import cloud.commandframework.context.CommandContext;
@@ -29,7 +30,7 @@ public class Cmd_Show extends MyMaidLibrary implements CommandPremise {
     public MyMaidCommand.Detail details() {
         return new MyMaidCommand.Detail(
             "show",
-            "Hide状態を解除します。"
+            "姿を見えるようにします。"
         );
     }
 
@@ -37,14 +38,13 @@ public class Cmd_Show extends MyMaidLibrary implements CommandPremise {
     public MyMaidCommand.Cmd register(Command.Builder<CommandSender> builder) {
         return new MyMaidCommand.Cmd(
             builder
-                .meta(CommandMeta.DESCRIPTION, "Hide状態を解除します。")
+                .meta(CommandMeta.DESCRIPTION, "姿を見えるようにします。")
                 .senderType(Player.class)
                 .handler(this::liftHid)
                 .build(),
             builder
-                .meta(CommandMeta.DESCRIPTION, "指定したプレイヤーのHide状態を解除します。")
-                .senderType(Player.class)
-                .argument(PlayerArgument.of("target"))
+                .meta(CommandMeta.DESCRIPTION, "指定したプレイヤーの姿を見えるようにします。")
+                .argument(PlayerArgument.of("target"), ArgumentDescription.of("対象のプレイヤー"))
                 .handler(this::liftHidOther)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Show.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Show.java
@@ -12,6 +12,7 @@
 package com.jaoafa.mymaid4.command;
 
 import cloud.commandframework.Command;
+import cloud.commandframework.bukkit.parsers.PlayerArgument;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.meta.CommandMeta;
 import com.jaoafa.mymaid4.Main;
@@ -38,12 +39,18 @@ public class Cmd_Show extends MyMaidLibrary implements CommandPremise {
             builder
                 .meta(CommandMeta.DESCRIPTION, "Hide状態を解除します。")
                 .senderType(Player.class)
-                .handler(this::addHid)
+                .handler(this::liftHid)
+                .build(),
+            builder
+                .meta(CommandMeta.DESCRIPTION, "指定したプレイヤーのHide状態を解除します。")
+                .senderType(Player.class)
+                .argument(PlayerArgument.of("target"))
+                .handler(this::liftHidOther)
                 .build()
         );
     }
 
-    void addHid(CommandContext<CommandSender> context) {
+    void liftHid(CommandContext<CommandSender> context) {
         Player player = (Player) context.getSender();
         if (!isAMR(player)) {
             SendMessage(player, details(), "あなたの権限ではこのコマンドを実行することができません！");
@@ -57,5 +64,27 @@ public class Cmd_Show extends MyMaidLibrary implements CommandPremise {
             MyMaidData.removeHid(player.getUniqueId());
         }
         SendMessage(player, details(), "あなたは他のプレイヤーから見えるようになりました。");
+    }
+
+    void liftHidOther(CommandContext<CommandSender> context) {
+        Player player = (Player) context.getSender();
+        Player target = context.get("target");
+        if (!isAMR(player)) {
+            SendMessage(player, details(), "あなたの権限ではこのコマンドを実行することができません！");
+            return;
+        }
+        if (!isAMR(target)) {
+            SendMessage(player, details(), "対象のプレイヤーの権限がRegular以上でないため、実行できません。");
+            return;
+        }
+
+        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+            p.showPlayer(Main.getJavaPlugin(), target);
+        }
+        if (MyMaidData.isHid(target.getUniqueId())) {
+            MyMaidData.removeHid(target.getUniqueId());
+        }
+        SendMessage(target, details(), "あなたは他のプレイヤーから見えるようになりました。");
+        SendMessage(player, details(), "プレイヤー「" + target.getName() + "」をから見えるようにしました。");
     }
 }

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Show.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Show.java
@@ -12,7 +12,6 @@
 package com.jaoafa.mymaid4.command;
 
 import cloud.commandframework.Command;
-import cloud.commandframework.bukkit.parsers.PlayerArgument;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.meta.CommandMeta;
 import com.jaoafa.mymaid4.Main;
@@ -40,12 +39,6 @@ public class Cmd_Show extends MyMaidLibrary implements CommandPremise {
                 .meta(CommandMeta.DESCRIPTION, "Hide状態を解除します。")
                 .senderType(Player.class)
                 .handler(this::liftHid)
-                .build(),
-            builder
-                .meta(CommandMeta.DESCRIPTION, "指定したプレイヤーのHide状態を解除します。")
-                .senderType(Player.class)
-                .argument(PlayerArgument.of("target"))
-                .handler(this::liftHidOther)
                 .build()
         );
     }
@@ -64,27 +57,5 @@ public class Cmd_Show extends MyMaidLibrary implements CommandPremise {
             MyMaidData.removeHid(player.getUniqueId());
         }
         SendMessage(player, details(), "あなたは他のプレイヤーから見えるようになりました。");
-    }
-
-    void liftHidOther(CommandContext<CommandSender> context) {
-        Player player = (Player) context.getSender();
-        Player target = context.get("target");
-        if (!isAMR(player)) {
-            SendMessage(player, details(), "あなたの権限ではこのコマンドを実行することができません！");
-            return;
-        }
-        if (!isAMR(target)) {
-            SendMessage(player, details(), "対象のプレイヤーの権限がRegular以上でないため、実行できません。");
-            return;
-        }
-
-        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
-            p.showPlayer(Main.getJavaPlugin(), target);
-        }
-        if (MyMaidData.isHid(target.getUniqueId())) {
-            MyMaidData.removeHid(target.getUniqueId());
-        }
-        SendMessage(target, details(), "あなたは他のプレイヤーから見えるようになりました。");
-        SendMessage(player, details(), "プレイヤー「" + target.getName() + "」をから見えるようにしました。");
     }
 }

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_TempMute.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_TempMute.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.BooleanArgument;
 import cloud.commandframework.context.CommandContext;
@@ -41,7 +42,7 @@ public class Cmd_TempMute extends MyMaidLibrary implements CommandPremise {
                 .senderType(Player.class)
                 .argument(BooleanArgument
                     .<CommandSender>newBuilder("changeTo")
-                    .asOptional())
+                    .asOptional(), ArgumentDescription.of("オン・オフのいずれか (未指定の場合トグル)"))
                 .handler(this::changeTempMute)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Time.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Time.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.BooleanArgument;
 import cloud.commandframework.arguments.standard.IntegerArgument;
@@ -42,16 +43,16 @@ public class Cmd_Time extends MyMaidLibrary implements CommandPremise {
             builder
                 .meta(CommandMeta.DESCRIPTION, "自分だけに適用される時間を設定します。")
                 .literal("set")
-                .argument(StringArgument.of("timeName"))
-                .argument(BooleanArgument.optional("isRelative"))
+                .argument(StringArgument.of("timeName"), ArgumentDescription.of("時間の名前"))
+                .argument(BooleanArgument.optional("isRelative"), ArgumentDescription.of("ワールド時間と相対的に保つか"))
                 .senderType(Player.class)
                 .handler(this::timeSetByName)
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "自分だけに適用される時間を進めます。")
                 .literal("add")
-                .argument(IntegerArgument.of("timeInt"))
-                .argument(BooleanArgument.optional("isRelative"))
+                .argument(IntegerArgument.of("timeInt"), ArgumentDescription.of("時間"))
+                .argument(BooleanArgument.optional("isRelative"), ArgumentDescription.of("ワールド時間と相対的に保つか"))
                 .senderType(Player.class)
                 .handler(this::timeAddByInt)
                 .build()

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Var.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Var.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.IntegerArgument;
 import cloud.commandframework.arguments.standard.StringArgument;
@@ -47,8 +48,8 @@ public class Cmd_Var extends MyMaidLibrary implements CommandPremise {
                 .literal("text", "set")
                 .argument(StringArgument
                     .<CommandSender>newBuilder("key")
-                    .withSuggestionsProvider(this::suggestVariableNames))
-                .argument(StringArgument.of("value"))
+                    .withSuggestionsProvider(this::suggestVariableNames), ArgumentDescription.of("変数名"))
+                .argument(StringArgument.of("value"), ArgumentDescription.of("代入する値"))
                 .handler(this::setVariable)
                 .build(),
             builder
@@ -56,72 +57,72 @@ public class Cmd_Var extends MyMaidLibrary implements CommandPremise {
                 .literal("plus", "add")
                 .argument(StringArgument
                     .<CommandSender>newBuilder("setToKey")
-                    .withSuggestionsProvider(this::suggestVariableNames))
+                    .withSuggestionsProvider(this::suggestVariableNames), ArgumentDescription.of("結果を代入する変数名"))
                 .argument(StringArgument
                     .<CommandSender>newBuilder("keyOrValue1")
-                    .withSuggestionsProvider(this::suggestVariableNames))
+                    .withSuggestionsProvider(this::suggestVariableNames), ArgumentDescription.of("加算する変数名もしくは値"))
                 .argument(StringArgument
                     .<CommandSender>newBuilder("keyOrValue2")
-                    .withSuggestionsProvider(this::suggestVariableNames))
-                .handler(c -> processVariable(c, CalcUnit.PLUS))
+                    .withSuggestionsProvider(this::suggestVariableNames), ArgumentDescription.of("加算する変数名もしくは値"))
+                .handler(c -> processVariable(c, MathSign.PLUS))
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "減算し、結果を変数に代入します。")
                 .literal("minus", "remove", "rem", "rm", "subtraction", "sub")
                 .argument(StringArgument
                     .<CommandSender>newBuilder("setToKey")
-                    .withSuggestionsProvider(this::suggestVariableNames))
+                    .withSuggestionsProvider(this::suggestVariableNames), ArgumentDescription.of("結果を代入する変数名"))
                 .argument(StringArgument
                     .<CommandSender>newBuilder("keyOrValue1")
-                    .withSuggestionsProvider(this::suggestVariableNames))
+                    .withSuggestionsProvider(this::suggestVariableNames), ArgumentDescription.of("減算される変数名もしくは値"))
                 .argument(StringArgument
                     .<CommandSender>newBuilder("keyOrValue2")
-                    .withSuggestionsProvider(this::suggestVariableNames))
-                .handler(c -> processVariable(c, CalcUnit.MINUS))
+                    .withSuggestionsProvider(this::suggestVariableNames), ArgumentDescription.of("減算する変数名もしくは値"))
+                .handler(c -> processVariable(c, MathSign.MINUS))
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "乗算し、結果を変数に代入します。")
                 .literal("multiply", "multi")
                 .argument(StringArgument
                     .<CommandSender>newBuilder("setToKey")
-                    .withSuggestionsProvider(this::suggestVariableNames))
+                    .withSuggestionsProvider(this::suggestVariableNames), ArgumentDescription.of("結果を代入する変数名"))
                 .argument(StringArgument
                     .<CommandSender>newBuilder("keyOrValue1")
-                    .withSuggestionsProvider(this::suggestVariableNames))
+                    .withSuggestionsProvider(this::suggestVariableNames), ArgumentDescription.of("乗算される変数名もしくは値"))
                 .argument(StringArgument
                     .<CommandSender>newBuilder("keyOrValue2")
-                    .withSuggestionsProvider(this::suggestVariableNames))
-                .handler(c -> processVariable(c, CalcUnit.MULTIPLY))
+                    .withSuggestionsProvider(this::suggestVariableNames), ArgumentDescription.of("乗算する変数名もしくは値"))
+                .handler(c -> processVariable(c, MathSign.MULTIPLY))
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "除算し、結果を変数に代入します。")
                 .literal("division", "div")
                 .argument(StringArgument
                     .<CommandSender>newBuilder("setToKey")
-                    .withSuggestionsProvider(this::suggestVariableNames))
+                    .withSuggestionsProvider(this::suggestVariableNames), ArgumentDescription.of("結果を代入する変数名"))
                 .argument(StringArgument
                     .<CommandSender>newBuilder("keyOrValue1")
-                    .withSuggestionsProvider(this::suggestVariableNames))
+                    .withSuggestionsProvider(this::suggestVariableNames), ArgumentDescription.of("除算される変数名もしくは値"))
                 .argument(StringArgument
                     .<CommandSender>newBuilder("keyOrValue2")
-                    .withSuggestionsProvider(this::suggestVariableNames))
-                .handler(c -> processVariable(c, CalcUnit.DIVIDE))
+                    .withSuggestionsProvider(this::suggestVariableNames), ArgumentDescription.of("乗算する変数名もしくは値"))
+                .handler(c -> processVariable(c, MathSign.DIVIDE))
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "計算し、結果を変数に代入します。")
                 .literal("calc")
                 .argument(StringArgument
                     .<CommandSender>newBuilder("setToKey")
-                    .withSuggestionsProvider(this::suggestVariableNames))
+                    .withSuggestionsProvider(this::suggestVariableNames), ArgumentDescription.of("結果を代入する変数名"))
                 .argument(StringArgument
                     .<CommandSender>newBuilder("keyOrValue1")
-                    .withSuggestionsProvider(this::suggestVariableNames))
+                    .withSuggestionsProvider(this::suggestVariableNames), ArgumentDescription.of("計算される変数名もしくは値"))
                 .argument(StringArgument
-                    .<CommandSender>newBuilder("unit")
-                    .withSuggestionsProvider((context, current) -> Arrays.asList("+", "-", "*", "/")))
+                    .<CommandSender>newBuilder("mathSign")
+                    .withSuggestionsProvider((context, current) -> Arrays.asList("+", "-", "*", "/")), ArgumentDescription.of("計算記号"))
                 .argument(StringArgument
                     .<CommandSender>newBuilder("keyOrValue2")
-                    .withSuggestionsProvider(this::suggestVariableNames))
+                    .withSuggestionsProvider(this::suggestVariableNames), ArgumentDescription.of("計算する変数名もしくは値"))
                 .handler(this::calcVariable)
                 .build(),
             builder
@@ -129,13 +130,13 @@ public class Cmd_Var extends MyMaidLibrary implements CommandPremise {
                 .literal("output", "out", "view")
                 .argument(StringArgument
                     .<CommandSender>newBuilder("key")
-                    .withSuggestionsProvider(this::suggestVariableNames))
+                    .withSuggestionsProvider(this::suggestVariableNames), ArgumentDescription.of("変数名"))
                 .handler(this::outputVariable)
                 .build(),
             builder
                 .meta(CommandMeta.DESCRIPTION, "キーの一覧を表示します。")
                 .literal("list")
-                .argument(IntegerArgument.optional("page", 1))
+                .argument(IntegerArgument.optional("page", 1), ArgumentDescription.of("ページ"))
                 .handler(this::listVariable)
                 .build(),
             builder
@@ -143,7 +144,7 @@ public class Cmd_Var extends MyMaidLibrary implements CommandPremise {
                 .literal("clear", "reset")
                 .argument(StringArgument
                     .<CommandSender>newBuilder("key")
-                    .withSuggestionsProvider(this::suggestVariableNames))
+                    .withSuggestionsProvider(this::suggestVariableNames), ArgumentDescription.of("削除する変数の変数名"))
                 .handler(this::clearVariable)
                 .build()
         );
@@ -173,7 +174,7 @@ public class Cmd_Var extends MyMaidLibrary implements CommandPremise {
         SendMessage(sender, details(), "変数「" + key + "」に値「" + value + "」を代入しました。");
     }
 
-    void processVariable(CommandContext<CommandSender> context, CalcUnit unit) {
+    void processVariable(CommandContext<CommandSender> context, MathSign unit) {
         CommandSender sender = context.getSender();
         String setToKey = context.get("setToKey");
         String keyOrValue1 = context.get("keyOrValue1");
@@ -207,7 +208,7 @@ public class Cmd_Var extends MyMaidLibrary implements CommandPremise {
         CommandSender sender = context.getSender();
         String setToKey = context.get("setToKey");
         String keyOrValue1 = context.get("keyOrValue1");
-        String unit = context.get("unit");
+        String mathSign = context.get("mathSign");
         String keyOrValue2 = context.get("keyOrValue2");
 
         if (!pattern.matcher(setToKey).matches()) {
@@ -231,9 +232,9 @@ public class Cmd_Var extends MyMaidLibrary implements CommandPremise {
             return;
         }
 
-        if (CalcUnit.fromId(unit).isEmpty()) return;
+        if (MathSign.fromId(mathSign).isEmpty()) return;
 
-        calcProcess(sender, setToKey, value1, value2, CalcUnit.fromId(unit).get());
+        calcProcess(sender, setToKey, value1, value2, MathSign.fromId(mathSign).get());
     }
 
     void outputVariable(CommandContext<CommandSender> context) {
@@ -303,11 +304,11 @@ public class Cmd_Var extends MyMaidLibrary implements CommandPremise {
         }
     }
 
-    void calcProcess(CommandSender sender, String key, int value1, int value2, CalcUnit unit) {
+    void calcProcess(CommandSender sender, String key, int value1, int value2, MathSign mathSign) {
         VariableManager vm = MyMaidData.getVariableManager();
 
         int result;
-        switch (unit) {
+        switch (mathSign) {
             case PLUS:
                 result = value1 + value2;
                 break;
@@ -321,35 +322,35 @@ public class Cmd_Var extends MyMaidLibrary implements CommandPremise {
                 result = value1 / value2;
                 break;
             default:
-                throw new IllegalStateException("Unexpected value: " + unit);
+                throw new IllegalStateException("Unexpected value: " + mathSign);
         }
 
         vm.set(key, result);
-        SendMessage(sender, details(), String.format("「%d」%s「%d」を%s結果である「%d」をキー「%s」にセットしました。", value1, unit.andOr, value2, unit.what, result, key));
+        SendMessage(sender, details(), String.format("「%d」%s「%d」を%s結果である「%d」をキー「%s」にセットしました。", value1, mathSign.andOr, value2, mathSign.what, result, key));
     }
 
     List<String> suggestVariableNames(final CommandContext<CommandSender> context, final String current) {
         return new ArrayList<>(MyMaidData.getVariableManager().getVariables().keySet());
     }
 
-    enum CalcUnit {
+    enum MathSign {
         PLUS("+", "と", "足した"),
         MINUS("-", "から", "引いた"),
         MULTIPLY("*", "と", "掛けた"),
         DIVIDE("/", "から", "割った");
 
-        final String unitId;
+        final String signId;
         final String andOr;
         final String what;
 
-        CalcUnit(String unitId, String andOr, String what) {
-            this.unitId = unitId;
+        MathSign(String signId, String andOr, String what) {
+            this.signId = signId;
             this.andOr = andOr;
             this.what = what;
         }
 
-        public static Optional<CalcUnit> fromId(String unitId) {
-            return Arrays.stream(values()).filter(u -> u.unitId.equals(unitId)).findFirst();
+        public static Optional<MathSign> fromId(String signId) {
+            return Arrays.stream(values()).filter(u -> u.signId.equals(signId)).findFirst();
         }
     }
 }

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_VarCmd.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_VarCmd.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.context.CommandContext;
@@ -49,7 +50,7 @@ public class Cmd_VarCmd extends MyMaidLibrary implements CommandPremise {
         return new MyMaidCommand.Cmd(
             builder
                 .meta(CommandMeta.DESCRIPTION, "変数を含むコマンドの変数を置き換え、実行します。")
-                .argument(StringArgument.greedy("command"))
+                .argument(StringArgument.greedy("command"), ArgumentDescription.of("変数を含むコマンド"))
                 .handler(this::runCommand)
                 .build()
         );

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Weather.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Weather.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.context.CommandContext;
@@ -41,7 +42,9 @@ public class Cmd_Weather extends MyMaidLibrary implements CommandPremise {
             builder
                 .meta(CommandMeta.DESCRIPTION, "自分だけに適用される天気を設定します。")
                 .literal("set")
-                .argument(StringArgument.<CommandSender>newBuilder("weatherName").withSuggestionsProvider(this::suggestWeatherName))
+                .argument(StringArgument
+                    .<CommandSender>newBuilder("weatherName")
+                    .withSuggestionsProvider(this::suggestWeatherName), ArgumentDescription.of("天気名"))
                 .senderType(Player.class)
                 .handler(this::weatherSetByName)
                 .build()

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Wt.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Wt.java
@@ -11,6 +11,7 @@
 
 package com.jaoafa.mymaid4.command;
 
+import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.bukkit.parsers.PlayerArgument;
 import cloud.commandframework.context.CommandContext;
@@ -53,8 +54,7 @@ public class Cmd_Wt extends MyMaidLibrary implements CommandPremise {
                 .senderType(Player.class)
                 .argument(StringArgument
                     .<CommandSender>newBuilder("worldName")
-                    .single()
-                    .withSuggestionsProvider(MyMaidLibrary::suggestWorldNames))
+                    .withSuggestionsProvider(MyMaidLibrary::suggestWorldNames), ArgumentDescription.of("ワールド名もしくはワールド番号"))
                 .handler(this::worldTeleport)
                 .build(),
 
@@ -62,9 +62,8 @@ public class Cmd_Wt extends MyMaidLibrary implements CommandPremise {
                 .meta(CommandMeta.DESCRIPTION, "指定したプレイヤーを指定したワールドにテレポートさせます。")
                 .argument(StringArgument
                     .<CommandSender>newBuilder("worldName")
-                    .single()
-                    .withSuggestionsProvider(MyMaidLibrary::suggestWorldNames))
-                .argument(PlayerArgument.of("player"))
+                    .withSuggestionsProvider(MyMaidLibrary::suggestWorldNames), ArgumentDescription.of("ワールド名もしくはワールド番号"))
+                .argument(PlayerArgument.of("player"), ArgumentDescription.of("テレポートさせるプレイヤー"))
                 .handler(this::worldTeleportPlayer)
                 .build()
 

--- a/src/main/java/com/jaoafa/mymaid4/lib/MyMaidConfig.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/MyMaidConfig.java
@@ -161,7 +161,7 @@ public class MyMaidConfig {
         return serverChatChannelId;
     }
 
-    public String getGithubAccessToken() {
+    public String getGitHubAccessToken() {
         return githubAccessToken;
     }
 }


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

- 各コマンドの引数に説明を追加
- `MyMaidConfig.getGithubAccessToken` -> `MyMaidConfig.getGitHubAccessToken`

## 進捗

- [x] /brb
- [x] /bug
- /calctree (既存)
- [x] /chat
- [x] /chatban
- /cmdb (既存)
- [x] /dt
- [x] /debstick
- [x] /ded
- [x] /dedmessage
- /dedbull (既存)
- [x] /delhome
- [x] /discordlink
- [x] /eban
- /elytra (既存)
- [x] /flyspeed
- [x] /g
- /getuserkey (既存)
- /getlookloc (既存)
- [x] /glookup
- /hat (既存)
- [x] /head
- [x] /help
- [x] /hide
- [x] /history
- [x] /home
- [x] /invload
- [x] /invsave
- [x] /jail
- /lead (既存)
- /link (既存)
- /logintext (既存)
- [x] /looking
- /makecmd (既存)
- /mymaid4 (既存)
- [x] /pigeon
- [x] /player
- /respawn (既存)
- /rider (既存)
- [x] /skkcolor
- /selclick (既存)
- [x] /sethome
- [x] /show
- /sign (既存)
- /spawn (既存)
- [x] /tempmute
- /test (既存)
- /testment (既存)
- [x] /time
- /tpdeny (既存)
- [x] /var
- [x] /varcmd
- /walkspeed (既存)
- [x] /weather
- /wire (既存)
- [x] /wt