### PR TITLE
feat: history addしたときにDiscord#jaohistoryに通知するように

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_History.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_History.java
@@ -95,7 +95,7 @@ public class Cmd_History extends MyMaidLibrary implements CommandPremise {
         String message = context.get("message");
 
         Historyjao histjao = Historyjao.getHistoryjao(target);
-        boolean bool = histjao.add(message);
+        boolean bool = histjao.add(message, context.getSender());
         SendMessage(sender, details(), String.format("%s の jaoHistory への登録に%sしました。", target.getName(), bool ? "成功" : "失敗"));
     }
 


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

`/history add` を実行した際、公式Discord鯖 LOGGERカテゴリの `#jaohistory` チャンネルに通知する

## 関連する Issue

close #518 

## チェックリスト

- [x] 【必須】[CONTRIBUTING](https://github.com/jaoafa/MyMaid4/blob/master/CONTRIBUTING.md) を読みました
- [x] 【必須】テストサーバで動作確認をしました
  - [x] ローカルサーバで動作確認しました
  - [ ] ZakuroHatのテストサーバで動作確認しました
- [x] 【必須】プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- [x] 【必須】`NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [x] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
  - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [ ] 複数のクラスにわたって使用される変数があるので、 `MyMaidData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `MyMaidLibrary` にその関数を作成し管理しています

## 追加情報

レビューよろ
