### PR TITLE
feat: Verifed以下が実行したコマンドをRegularに表示するように & AMに表示されるコマンドログの形式を変更 & secrettpコマンドの追加

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_SecretTP.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_SecretTP.java
@@ -38,12 +38,12 @@ public class Cmd_SecretTP extends MyMaidLibrary implements CommandPremise {
             builder
                 .meta(CommandMeta.DESCRIPTION, "スぺテクターで特定のプレイヤーにテレポートします。")
                 .argument(PlayerArgument.of("player"), ArgumentDescription.of("テレポートするプレイヤー名"))
-                .handler(this::giveBarrierToPlayer)
+                .handler(this::secretTP)
                 .build()
         );
     }
 
-    void giveBarrierToPlayer(CommandContext<CommandSender> context) {
+    void secretTP(CommandContext<CommandSender> context) {
         Player target = context.getOrDefault("player", null);
         Player player = (Player) context.getSender();
         if (target == null) return;

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_SecretTP.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_SecretTP.java
@@ -28,7 +28,7 @@ public class Cmd_SecretTP extends MyMaidLibrary implements CommandPremise {
     public MyMaidCommand.Detail details() {
         return new MyMaidCommand.Detail(
             "secrettp",
-            "スぺテクターでテレポートします。"
+            "スペクテイターでテレポートします。"
         );
     }
 
@@ -53,6 +53,6 @@ public class Cmd_SecretTP extends MyMaidLibrary implements CommandPremise {
         }
         target.setGameMode(GameMode.SPECTATOR);
         target.teleport(target);
-        SendMessage(player,details(),target.getName()+"にスペクテイターでテレポートしました。");
+        SendMessage(player, details(), target.getName() + "にスペクテイターでテレポートしました。");
     }
 }

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_SecretTP.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_SecretTP.java
@@ -36,7 +36,7 @@ public class Cmd_SecretTP extends MyMaidLibrary implements CommandPremise {
     public MyMaidCommand.Cmd register(Command.Builder<CommandSender> builder) {
         return new MyMaidCommand.Cmd(
             builder
-                .meta(CommandMeta.DESCRIPTION, "スぺテクターで特定のプレイヤーにテレポートします。")
+                .meta(CommandMeta.DESCRIPTION, "スペクテイターで特定のプレイヤーにテレポートします。")
                 .argument(PlayerArgument.of("player"), ArgumentDescription.of("テレポートするプレイヤー名"))
                 .handler(this::secretTP)
                 .build()
@@ -53,6 +53,6 @@ public class Cmd_SecretTP extends MyMaidLibrary implements CommandPremise {
         }
         target.setGameMode(GameMode.SPECTATOR);
         target.teleport(target);
-        SendMessage(player,details(),target.getName()+"にスぺテクターでテレポートしました。");
+        SendMessage(player,details(),target.getName()+"にスペクテイターでテレポートしました。");
     }
 }

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_SecretTP.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_SecretTP.java
@@ -1,0 +1,58 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.mymaid4.command;
+
+import cloud.commandframework.ArgumentDescription;
+import cloud.commandframework.Command;
+import cloud.commandframework.bukkit.parsers.PlayerArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.meta.CommandMeta;
+import com.jaoafa.mymaid4.lib.CommandPremise;
+import com.jaoafa.mymaid4.lib.MyMaidCommand;
+import com.jaoafa.mymaid4.lib.MyMaidLibrary;
+import org.bukkit.GameMode;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class Cmd_SecretTP extends MyMaidLibrary implements CommandPremise {
+    @Override
+    public MyMaidCommand.Detail details() {
+        return new MyMaidCommand.Detail(
+            "secrettp",
+            "スぺテクターでテレポートします。"
+        );
+    }
+
+    @Override
+    public MyMaidCommand.Cmd register(Command.Builder<CommandSender> builder) {
+        return new MyMaidCommand.Cmd(
+            builder
+                .meta(CommandMeta.DESCRIPTION, "スぺテクターで特定のプレイヤーにテレポートします。")
+                .argument(PlayerArgument.of("player"), ArgumentDescription.of("テレポートするプレイヤー名"))
+                .handler(this::giveBarrierToPlayer)
+                .build()
+        );
+    }
+
+    void giveBarrierToPlayer(CommandContext<CommandSender> context) {
+        Player target = context.getOrDefault("player", null);
+        Player player = (Player) context.getSender();
+        if (target == null) return;
+        if (!isAMR(player)) {
+            SendMessage(target, details(), "あなたの権限ではこのコマンドを実行することができません！");
+            return;
+        }
+        target.setGameMode(GameMode.SPECTATOR);
+        target.teleport(target);
+        SendMessage(player,details(),target.getName()+"にスぺテクターでテレポートしました。");
+    }
+}

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendAM.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendAM.java
@@ -14,8 +14,13 @@ package com.jaoafa.mymaid4.event;
 import com.jaoafa.mymaid4.lib.EventPremise;
 import com.jaoafa.mymaid4.lib.MyMaidData;
 import com.jaoafa.mymaid4.lib.MyMaidLibrary;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -34,16 +39,50 @@ public class Event_CommandSendAM extends MyMaidLibrary implements Listener, Even
         String command = event.getMessage();
         if (isAMRV(player)) {
             // Default以上は実行試行したコマンドを返す
-            player.sendMessage(ChatColor.DARK_GRAY + "Cmd: " + command); // 仮
+            player.sendMessage(
+                Component.text()
+                    .color(NamedTextColor.DARK_GRAY)
+                    .append(
+                        Component.text("["),
+                        Component.text("Cmd", Style.style(TextDecoration.UNDERLINED, ClickEvent.copyToClipboard(command)).toBuilder().build()),
+                        Component.text("] " + command)
+                    )
+            );
         }
         String group = getPermissionMainGroup(player);
         for (Player p : Bukkit.getServer().getOnlinePlayers()) {
             if (isAM(p) && (!player.getName().equals(p.getName()))) {
-                if (MyMaidData.getTempMuting().contains(player)) {
-                    return;
-                }
+                if (MyMaidData.getTempMuting().contains(player)) return;
+
                 p.sendMessage(
-                    ChatColor.GRAY + "(" + group + ") " + player.getName() + ": " + ChatColor.YELLOW + command + (event.isCancelled() ? ChatColor.RED + " (Canceled)" : ""));
+                    Component.text()
+                        .color(NamedTextColor.DARK_GRAY)
+                        .append(
+                            // [Group/PlayerName] command test test (取り消し済み)
+                            Component.text(
+                                String.format("[%s/", group),
+                                NamedTextColor.GRAY
+                            ),
+                            Component.text(
+                                player.getName(),
+                                Style.style()
+                                    .color(NamedTextColor.DARK_AQUA)
+                                    .decorate(TextDecoration.UNDERLINED)
+                                    .clickEvent(ClickEvent.runCommand("/g sp"))
+                                    .clickEvent(ClickEvent.runCommand("/tp " + player.getName()))
+                                    .hoverEvent(HoverEvent.showText(
+                                        Component.text(String.format("スぺテクターで%sにテレポート", player.getName()))
+                                    ))
+                                    .build()
+                            ),
+                            Component.text(
+                                "] ",
+                                NamedTextColor.GRAY
+                            ),
+                            Component.text(command, NamedTextColor.YELLOW),
+                            Component.text((event.isCancelled() ? " (取り消し済み)" : ""), NamedTextColor.RED)
+                        )
+                );
             }
         }
 

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendAM.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendAM.java
@@ -66,11 +66,11 @@ public class Event_CommandSendAM extends MyMaidLibrary implements Listener, Even
                             Component.text(
                                 player.getName(),
                                 Style.style()
-                                    .color(NamedTextColor.DARK_AQUA)
+                                    .color(NamedTextColor.GRAY)
                                     .decorate(TextDecoration.UNDERLINED)
                                     .clickEvent(ClickEvent.runCommand("/secrettp " + player.getName()))
                                     .hoverEvent(HoverEvent.showText(
-                                        Component.text(String.format("スぺテクターで%sにテレポート", player.getName()))
+                                        Component.text(String.format("スペクテイターで%sにテレポート", player.getName()))
                                     ))
                                     .build()
                             ),
@@ -79,7 +79,7 @@ public class Event_CommandSendAM extends MyMaidLibrary implements Listener, Even
                                 NamedTextColor.GRAY
                             ),
                             Component.text(command, NamedTextColor.YELLOW),
-                            Component.text((event.isCancelled() ? " (取り消し済み)" : ""), NamedTextColor.RED)
+                            Component.text((event.isCancelled() ? " (拒否)" : ""), NamedTextColor.RED)
                         )
                 );
             }

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendAM.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendAM.java
@@ -68,8 +68,7 @@ public class Event_CommandSendAM extends MyMaidLibrary implements Listener, Even
                                 Style.style()
                                     .color(NamedTextColor.DARK_AQUA)
                                     .decorate(TextDecoration.UNDERLINED)
-                                    .clickEvent(ClickEvent.runCommand("/g sp"))
-                                    .clickEvent(ClickEvent.runCommand("/tp " + player.getName()))
+                                    .clickEvent(ClickEvent.runCommand("/secrettp " + player.getName()))
                                     .hoverEvent(HoverEvent.showText(
                                         Component.text(String.format("スぺテクターで%sにテレポート", player.getName()))
                                     ))

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendR.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendR.java
@@ -41,37 +41,6 @@ public class Event_CommandSendR extends MyMaidLibrary implements Listener, Event
         for (Player p : Bukkit.getServer().getOnlinePlayers()) {
             //AMRかつAMではない = R
             //かつ実行者本人ではない
-            if (p.getName().equals("yuuaHP")) {
-                p.sendMessage(
-                    Component.text()
-                        .color(NamedTextColor.DARK_GRAY)
-                        .append(
-                            // [Group/PlayerName] command test test (取り消し済み)
-                            Component.text(
-                                String.format("[%s/", group),
-                                NamedTextColor.GRAY
-                            ),
-                            Component.text(
-                                player.getName(),
-                                Style.style()
-                                    .color(NamedTextColor.DARK_AQUA)
-                                    .decorate(TextDecoration.UNDERLINED)
-                                    .clickEvent(ClickEvent.runCommand("/secrettp " + player.getName()))
-                                    .hoverEvent(HoverEvent.showText(
-                                        Component.text(String.format("スぺテクターで%sにテレポート", player.getName()))
-                                    ))
-                                    .build()
-                            ),
-                            Component.text(
-                                "] ",
-                                NamedTextColor.GRAY
-                            ),
-                            Component.text(command, NamedTextColor.YELLOW),
-                            Component.text((event.isCancelled() ? " (取り消し済み)" : ""), NamedTextColor.RED)
-                        )
-                );
-
-            }
             if (isAMR(p) && (!isAM(p)) && (!player.getName().equals(p.getName()))) {
                 if (MyMaidData.getTempMuting().contains(player)) return;
 

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendR.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendR.java
@@ -56,8 +56,7 @@ public class Event_CommandSendR extends MyMaidLibrary implements Listener, Event
                                 Style.style()
                                     .color(NamedTextColor.DARK_AQUA)
                                     .decorate(TextDecoration.UNDERLINED)
-                                    .clickEvent(ClickEvent.runCommand("/g sp"))
-                                    .clickEvent(ClickEvent.runCommand("/tp " + player.getName()))
+                                    .clickEvent(ClickEvent.runCommand("/secrettp " + player.getName()))
                                     .hoverEvent(HoverEvent.showText(
                                         Component.text(String.format("スぺテクターで%sにテレポート", player.getName()))
                                     ))

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendR.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendR.java
@@ -90,8 +90,7 @@ public class Event_CommandSendR extends MyMaidLibrary implements Listener, Event
                                 Style.style()
                                     .color(NamedTextColor.DARK_AQUA)
                                     .decorate(TextDecoration.UNDERLINED)
-                                    .clickEvent(ClickEvent.runCommand("/g sp"))
-                                    .clickEvent(ClickEvent.runCommand("/tp " + player.getName()))
+                                    .clickEvent(ClickEvent.runCommand("/secrettp " + player.getName()))
                                     .hoverEvent(HoverEvent.showText(
                                         Component.text(String.format("スぺテクターで%sにテレポート", player.getName()))
                                     ))

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendR.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendR.java
@@ -39,9 +39,7 @@ public class Event_CommandSendR extends MyMaidLibrary implements Listener, Event
         String command = event.getMessage();
         String group = getPermissionMainGroup(player);
         for (Player p : Bukkit.getServer().getOnlinePlayers()) {
-            //AMRかつAMではない = R
-            //かつ実行者本人ではない
-            if (isAMR(p) && (!isAM(p)) && (!player.getName().equals(p.getName()))) {
+            if (isR(p) && (!player.getName().equals(p.getName()))) {
                 if (MyMaidData.getTempMuting().contains(player)) return;
 
                 p.sendMessage(
@@ -56,11 +54,11 @@ public class Event_CommandSendR extends MyMaidLibrary implements Listener, Event
                             Component.text(
                                 player.getName(),
                                 Style.style()
-                                    .color(NamedTextColor.DARK_AQUA)
+                                    .color(NamedTextColor.GRAY)
                                     .decorate(TextDecoration.UNDERLINED)
                                     .clickEvent(ClickEvent.runCommand("/secrettp " + player.getName()))
                                     .hoverEvent(HoverEvent.showText(
-                                        Component.text(String.format("スぺテクターで%sにテレポート", player.getName()))
+                                        Component.text(String.format("スペクテイターで%sにテレポート", player.getName()))
                                     ))
                                     .build()
                             ),
@@ -69,7 +67,7 @@ public class Event_CommandSendR extends MyMaidLibrary implements Listener, Event
                                 NamedTextColor.GRAY
                             ),
                             Component.text(command, NamedTextColor.YELLOW),
-                            Component.text((event.isCancelled() ? " (取り消し済み)" : ""), NamedTextColor.RED)
+                            Component.text((event.isCancelled() ? " (拒否)" : ""), NamedTextColor.RED)
                         )
                 );
             }

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendR.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendR.java
@@ -55,6 +55,7 @@ public class Event_CommandSendR extends MyMaidLibrary implements Listener, Event
             //かつ実行者本人ではない
             if (isAMR(p) && (!isAM(p)) && (!player.getName().equals(p.getName()))) {
                 if (MyMaidData.getTempMuting().contains(player)) return;
+
                 p.sendMessage(
                     Component.text()
                         .color(NamedTextColor.DARK_GRAY)

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendR.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendR.java
@@ -41,6 +41,38 @@ public class Event_CommandSendR extends MyMaidLibrary implements Listener, Event
         for (Player p : Bukkit.getServer().getOnlinePlayers()) {
             //AMRかつAMではない = R
             //かつ実行者本人ではない
+            if (p.getName().equals("yuuaHP")) {
+                p.sendMessage(
+                    Component.text()
+                        .color(NamedTextColor.DARK_GRAY)
+                        .append(
+                            // [Group/PlayerName] command test test (取り消し済み)
+                            Component.text(
+                                String.format("[%s/", group),
+                                NamedTextColor.GRAY
+                            ),
+                            Component.text(
+                                player.getName(),
+                                Style.style()
+                                    .color(NamedTextColor.DARK_AQUA)
+                                    .decorate(TextDecoration.UNDERLINED)
+                                    .clickEvent(ClickEvent.runCommand("/g sp"))
+                                    .clickEvent(ClickEvent.runCommand("/tp " + player.getName()))
+                                    .hoverEvent(HoverEvent.showText(
+                                        Component.text(String.format("スぺテクターで%sにテレポート", player.getName()))
+                                    ))
+                                    .build()
+                            ),
+                            Component.text(
+                                "] ",
+                                NamedTextColor.GRAY
+                            ),
+                            Component.text(command, NamedTextColor.YELLOW),
+                            Component.text((event.isCancelled() ? " (取り消し済み)" : ""), NamedTextColor.RED)
+                        )
+                );
+
+            }
             if (isAMR(p) && (!isAM(p)) && (!player.getName().equals(p.getName()))) {
                 if (MyMaidData.getTempMuting().contains(player)) return;
 

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendR.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendR.java
@@ -37,18 +37,6 @@ public class Event_CommandSendR extends MyMaidLibrary implements Listener, Event
     public void onCommand(PlayerCommandPreprocessEvent event) {
         Player player = event.getPlayer();
         String command = event.getMessage();
-        if (isAMRV(player)) {
-            // Default以上は実行試行したコマンドを返す
-            player.sendMessage(
-                Component.text()
-                    .color(NamedTextColor.DARK_GRAY)
-                    .append(
-                        Component.text("["),
-                        Component.text("Cmd", Style.style(TextDecoration.UNDERLINED, ClickEvent.copyToClipboard(command)).toBuilder().build()),
-                        Component.text("] " + command)
-                    )
-            );
-        }
         String group = getPermissionMainGroup(player);
         for (Player p : Bukkit.getServer().getOnlinePlayers()) {
             //AMRかつAMではない = R

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendR.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_CommandSendR.java
@@ -1,0 +1,90 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.mymaid4.event;
+
+import com.jaoafa.mymaid4.lib.EventPremise;
+import com.jaoafa.mymaid4.lib.MyMaidData;
+import com.jaoafa.mymaid4.lib.MyMaidLibrary;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+
+public class Event_CommandSendR extends MyMaidLibrary implements Listener, EventPremise {
+    @Override
+    public String description() {
+        return "実行されたコマンドをRegularに通知します。";
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onCommand(PlayerCommandPreprocessEvent event) {
+        Player player = event.getPlayer();
+        String command = event.getMessage();
+        if (isAMRV(player)) {
+            // Default以上は実行試行したコマンドを返す
+            player.sendMessage(
+                Component.text()
+                    .color(NamedTextColor.DARK_GRAY)
+                    .append(
+                        Component.text("["),
+                        Component.text("Cmd", Style.style(TextDecoration.UNDERLINED, ClickEvent.copyToClipboard(command)).toBuilder().build()),
+                        Component.text("] " + command)
+                    )
+            );
+        }
+        String group = getPermissionMainGroup(player);
+        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+            //AMRかつAMではない = R
+            //かつ実行者本人ではない
+            if (isAMR(p) && (!isAM(p)) && (!player.getName().equals(p.getName()))) {
+                if (MyMaidData.getTempMuting().contains(player)) return;
+                p.sendMessage(
+                    Component.text()
+                        .color(NamedTextColor.DARK_GRAY)
+                        .append(
+                            // [Group/PlayerName] command test test (取り消し済み)
+                            Component.text(
+                                String.format("[%s/", group),
+                                NamedTextColor.GRAY
+                            ),
+                            Component.text(
+                                player.getName(),
+                                Style.style()
+                                    .color(NamedTextColor.DARK_AQUA)
+                                    .decorate(TextDecoration.UNDERLINED)
+                                    .clickEvent(ClickEvent.runCommand("/g sp"))
+                                    .clickEvent(ClickEvent.runCommand("/tp " + player.getName()))
+                                    .hoverEvent(HoverEvent.showText(
+                                        Component.text(String.format("スぺテクターで%sにテレポート", player.getName()))
+                                    ))
+                                    .build()
+                            ),
+                            Component.text(
+                                "] ",
+                                NamedTextColor.GRAY
+                            ),
+                            Component.text(command, NamedTextColor.YELLOW),
+                            Component.text((event.isCancelled() ? " (取り消し済み)" : ""), NamedTextColor.RED)
+                        )
+                );
+            }
+        }
+    }
+}

--- a/src/main/java/com/jaoafa/mymaid4/lib/MyMaidLibrary.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/MyMaidLibrary.java
@@ -275,6 +275,17 @@ public class MyMaidLibrary {
     }
 
     /**
+     * プレイヤーがRegularであるかを判定します。
+     *
+     * @param player 判定するプレイヤー
+     */
+    protected static boolean isR(OfflinePlayer player) {
+        String group = getPermissionMainGroup(player);
+        if (group == null) return false;
+        return group.equalsIgnoreCase("Regular");
+    }
+
+    /**
      * プレイヤーがVerifiedであるかを判定します。
      *
      * @param player 判定するプレイヤー


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

![image](https://user-images.githubusercontent.com/53546237/127455214-7e001341-d52f-474f-b613-ab2cce69cee6.png)
- VDが実行したコマンドをRに送信
- クリックするとスぺテクターでテレポートできるように
- ↑で使うため`/secrettp`を実装


## 関連する Issue

close #542

## チェックリスト

> `[ ]` を `[x]` にすることでチェックできます

- [x] 【必須】[CONTRIBUTING](https://github.com/jaoafa/MyMaid4/blob/master/CONTRIBUTING.md) を読みました
- [x] 【必須】テストサーバで動作確認をしました
  - [ ] ローカルサーバで動作確認しました
  - [x] ZakuroHatのテストサーバで動作確認しました
- [x] 【必須】プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- [x] 【必須】`NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [ ] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
  - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [ ] 複数のクラスにわたって使用される変数があるので、 `MyMaidData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `MyMaidLibrary` にその関数を作成し管理しています

## 追加情報
