### PR TITLE
fix: #533 埋めてあるマップは除外

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/event/Event_AntiToolbar.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_AntiToolbar.java
@@ -88,6 +88,10 @@ public class Event_AntiToolbar extends MyMaidLibrary implements Listener, EventP
             return;
         }
 
+        if (is.getType() == Material.FILLED_MAP) {
+            return; // #533 埋めてあるマップは除外
+        }
+
         event.setCurrentItem(null);
         event.setCursor(new ItemStack(Material.AIR));
         player.sendMessage(Component.text().append(


### PR DESCRIPTION
ImageOnMapマウス中クリコピー失敗の対策