### PR TITLE
feat: AntiDuplicateEntity

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_DedMessage.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_DedMessage.java
@@ -208,10 +208,10 @@ public class Cmd_DedMessage extends MyMaidLibrary implements CommandPremise {
             SendMessage(player, details(), componentHomeInfo);
         });
         Component footer = Component.text().append(
-            Component.text("---<< ")
+            Component.text("<[PREV] ")
                 .clickEvent(ClickEvent.runCommand(String.format("/dedmessage list %d", page - 1))),
             Component.text("[" + (page - 1) + "] PAGE", NamedTextColor.GOLD),
-            Component.text(" >>---")
+            Component.text(" [NEXT]>")
                 .clickEvent(ClickEvent.runCommand(String.format("/dedmessage list %d", page + 1)))
         ).build();
         SendMessage(player, details(), footer);

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Home.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Home.java
@@ -152,9 +152,9 @@ public class Cmd_Home extends MyMaidLibrary implements CommandPremise {
             SendMessage(player, details(), componentHomeInfo);
         });
         Component componentHomeInfo = Component.text().append(
-            Component.text("===<< ", Style.style().clickEvent(ClickEvent.runCommand("/home list " + finalVisualPagenumBefore)).build()),
+            Component.text("<[PREV] ", Style.style().clickEvent(ClickEvent.runCommand("/home list " + finalVisualPagenumBefore)).build()),
             Component.text("[" + finalVisualPagenum + "] PAGE", NamedTextColor.GOLD),
-            Component.text(" >>===", Style.style().clickEvent(ClickEvent.runCommand("/home list " + finalVisualPagenumAfter)).build())
+            Component.text(" [NEXT]>", Style.style().clickEvent(ClickEvent.runCommand("/home list " + finalVisualPagenumAfter)).build())
         ).build();
         SendMessage(player, details(), componentHomeInfo);
     }

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_AntiDuplicateEntity.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_AntiDuplicateEntity.java
@@ -1,0 +1,42 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2021 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.mymaid4.event;
+
+import com.jaoafa.mymaid4.lib.EventPremise;
+import com.jaoafa.mymaid4.lib.MyMaidLibrary;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+
+public class Event_AntiDuplicateEntity extends MyMaidLibrary implements Listener, EventPremise {
+    @Override
+    public String description() {
+        return "Default・Verified権限グループのプレイヤーによるエンティティのコピーを制限します。";
+    }
+
+    @EventHandler
+    public static void onCommand(PlayerCommandPreprocessEvent event) {
+        if (isAMR(event.getPlayer())) return;
+
+        String[] limitedCmd = new String[]{"//copy","//paste","//stack"};
+        String cmd = event.getMessage();
+
+        for (String cmdStart : limitedCmd) {
+            if (cmd.startsWith(cmdStart) && cmd.contains("-e")) {
+                event.getPlayer().sendMessage("[AntiDuplicateEntity] あなたの権限ではエンティティを複製することが出来ません！");
+            }
+        }
+    }
+}

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_AntiDuplicateEntity.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_AntiDuplicateEntity.java
@@ -36,6 +36,8 @@ public class Event_AntiDuplicateEntity extends MyMaidLibrary implements Listener
         for (String cmdStart : limitedCmd) {
             if (cmd.startsWith(cmdStart) && cmd.contains("-e")) {
                 event.getPlayer().sendMessage("[AntiDuplicateEntity] あなたの権限ではエンティティを複製することが出来ません！");
+                event.setCancelled(true);
+                return;
             }
         }
     }

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_AntiDuplicateEntity.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_AntiDuplicateEntity.java
@@ -15,7 +15,6 @@ import com.jaoafa.mymaid4.lib.EventPremise;
 import com.jaoafa.mymaid4.lib.MyMaidLibrary;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
@@ -30,12 +29,12 @@ public class Event_AntiDuplicateEntity extends MyMaidLibrary implements Listener
     public static void onCommand(PlayerCommandPreprocessEvent event) {
         if (isAMR(event.getPlayer())) return;
 
-        String[] limitedCmd = new String[]{"//copy","//paste","//stack"};
+        String[] limitedCmd = new String[]{"//copy", "//paste", "//stack"};
         String cmd = event.getMessage();
 
         for (String cmdStart : limitedCmd) {
             if (cmd.startsWith(cmdStart) && cmd.contains("-e")) {
-                event.getPlayer().sendMessage(Component.text("[AntiDuplicateEntity] あなたの権限ではエンティティを複製することが出来ません！",NamedTextColor.RED));
+                event.getPlayer().sendMessage(Component.text("[AntiDuplicateEntity] あなたの権限ではエンティティを複製することが出来ません！", NamedTextColor.RED));
                 event.setCancelled(true);
                 return;
             }

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_AntiDuplicateEntity.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_AntiDuplicateEntity.java
@@ -35,7 +35,7 @@ public class Event_AntiDuplicateEntity extends MyMaidLibrary implements Listener
 
         for (String cmdStart : limitedCmd) {
             if (cmd.startsWith(cmdStart) && cmd.contains("-e")) {
-                event.getPlayer().sendMessage("[AntiDuplicateEntity] あなたの権限ではエンティティを複製することが出来ません！");
+                event.getPlayer().sendMessage(Component.text("[AntiDuplicateEntity] あなたの権限ではエンティティを複製することが出来ません！",NamedTextColor.RED));
                 event.setCancelled(true);
                 return;
             }

--- a/src/main/java/com/jaoafa/mymaid4/lib/Jail.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/Jail.java
@@ -275,6 +275,7 @@ public class Jail {
                     Component.text(Objects.requireNonNull(player.getName()), NamedTextColor.GREEN)
                         .hoverEvent(HoverEvent.showEntity(Key.key("player"), player.getUniqueId(), Component.text(player.getName()))),
                     Component.text("」が遺言を残しました。", NamedTextColor.GREEN),
+                    Component.newline(),
                     Component.text("遺言:「", NamedTextColor.GREEN),
                     Component.text(testment, NamedTextColor.GREEN),
                     Component.text("」", NamedTextColor.GREEN)


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

#382 を実装 & ちょっと表示を変更(他機能)

## 関連する Issue

close #382

## チェックリスト

> `[ ]` を `[x]` にすることでチェックできます

- [x] 【必須】[CONTRIBUTING](https://github.com/jaoafa/MyMaid4/blob/master/CONTRIBUTING.md) を読みました
- [x] 【必須】テストサーバで動作確認をしました
  - [ ] ローカルサーバで動作確認しました
  - [x] ZakuroHatのテストサーバで動作確認しました
- [x] 【必須】プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- [x] 【必須】`NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [ ] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
  - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [ ] 複数のクラスにわたって使用される変数があるので、 `MyMaidData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `MyMaidLibrary` にその関数を作成し管理しています

## 追加情報

> 何か追加情報がある場合は記載してください


