### PR TITLE
fix: #568 jailの移動制限緩和 + Y55未満へは行けないように

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/event/Event_Jail.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_Jail.java
@@ -107,9 +107,10 @@ public class Event_Jail implements Listener, EventPremise {
             return;
         }
         double distance = prison.distance(to);
-        if (distance >= 40D) {
+        if (distance >= 50D || to.getBlockY() < 55) {
+            // 中央からの距離が50ブロック or y値が55未満
             player.sendMessage("[Jail] " + ChatColor.GREEN + "あなたは南の楽園から出られません！");
-            if (distance >= 50D) {
+            if (distance >= 60D) {
                 if (!player.teleport(prison, TeleportCause.PLUGIN)) {
                     // 失敗時
                     Location oldBed = player.getBedSpawnLocation();


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

- Jailの移動制限緩和（40ブロック→50ブロック）
- JailされているときはY55未満へは移動できないように

## 関連する Issue

- close #568 

## チェックリスト

> `[ ]` を `[x]` にすることでチェックできます

- [x] 【必須】[CONTRIBUTING](https://github.com/jaoafa/MyMaid4/blob/master/CONTRIBUTING.md) を読みました
- [x] 【必須】テストサーバで動作確認をしました
  - [x] ローカルサーバで動作確認しました
  - [ ] ZakuroHatのテストサーバで動作確認しました
- [x] 【必須】プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- [x] 【必須】`NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [x] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
  - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [ ] 複数のクラスにわたって使用される変数があるので、 `MyMaidData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `MyMaidLibrary` にその関数を作成し管理しています

## 追加情報

