### PR TITLE
fix: #571 連投によるスパム判定を変更 (disconnect.spamへ)

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/event/Event_DisableKicks.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_DisableKicks.java
@@ -27,13 +27,11 @@ public class Event_DisableKicks extends MyMaidLibrary implements Listener, Event
     @EventHandler
     public void onKick(PlayerKickEvent event) {
         String reason = PlainComponentSerializer.plain().serialize(event.reason());
-        // Kicked for spamming
-        if (reason.equals("Kicked for spamming")) {
+        if (reason.equals("disconnect.spam") || event.getCause() == PlayerKickEvent.Cause.SPAM) {
             event.setCancelled(true);
         }
         if (reason.startsWith("You dropped your items too quickly")) {
             event.setCancelled(true);
         }
     }
-
 }

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_NotifyKick.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_NotifyKick.java
@@ -14,7 +14,10 @@ package com.jaoafa.mymaid4.event;
 import com.jaoafa.mymaid4.lib.EventPremise;
 import com.jaoafa.mymaid4.lib.MyMaidLibrary;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -29,6 +32,7 @@ public class Event_NotifyKick extends MyMaidLibrary implements Listener, EventPr
     @EventHandler(priority = EventPriority.MONITOR,
                   ignoreCancelled = true)
     public void onKick(PlayerKickEvent event) {
+        String reason = PlainComponentSerializer.plain().serialize(event.reason());
         sendAM(Component.text().append(
             Component.text("[Kick]"),
             Component.space(),
@@ -36,6 +40,11 @@ public class Event_NotifyKick extends MyMaidLibrary implements Listener, EventPr
             Component.text(event.getPlayer().getName(), NamedTextColor.GREEN),
             Component.text("」は「", NamedTextColor.GREEN),
             event.reason(),
+            Component.text(" (", NamedTextColor.GREEN),
+            Component.text(reason)
+                .hoverEvent(HoverEvent.showText(Component.text("PlayerKickEvent.Cause." + event.getCause().name())))
+                .clickEvent(ClickEvent.copyToClipboard(reason)),
+            Component.text(")", NamedTextColor.GREEN),
             Component.text("」という理由でキックされました。", NamedTextColor.GREEN)
         ).build());
     }


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

- #571 短時間のスパム行為によるkickの無効化修正 (`disconnect.spam`へ)
- キック時の通知メッセージを一部変更

## 関連する Issue

- close #571 

## チェックリスト

- [x] 【必須】[CONTRIBUTING](https://github.com/jaoafa/MyMaid4/blob/master/CONTRIBUTING.md) を読みました
- [x] 【必須】テストサーバで動作確認をしました
  - [x] ローカルサーバで動作確認しました
  - [ ] ZakuroHatのテストサーバで動作確認しました
- [x] 【必須】プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- [x] 【必須】`NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [x] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
  - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [ ] 複数のクラスにわたって使用される変数があるので、 `MyMaidData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `MyMaidLibrary` にその関数を作成し管理しています

## 追加情報

なし
