### PR TITLE
fix: testment時の全体通知メッセージが改行されているのを修正

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/lib/Jail.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/Jail.java
@@ -274,8 +274,11 @@ public class Jail {
                     Component.text("プレイヤー「", NamedTextColor.GREEN),
                     Component.text(Objects.requireNonNull(player.getName()), NamedTextColor.GREEN)
                         .hoverEvent(HoverEvent.showEntity(Key.key("player"), player.getUniqueId(), Component.text(player.getName()))),
-                    Component.text("」が遺言を残しました。", NamedTextColor.GREEN),
-                    Component.newline(),
+                    Component.text("」が遺言を残しました。", NamedTextColor.GREEN)
+                ));
+                Bukkit.getServer().sendMessage(Component.text().append(
+                    Component.text("[Jail]"),
+                    Component.space(),
                     Component.text("遺言:「", NamedTextColor.GREEN),
                     Component.text(testment, NamedTextColor.GREEN),
                     Component.text("」", NamedTextColor.GREEN)


### PR DESCRIPTION
```
[Jail] プレイヤー「xxxxx」が遺言を残しました。
遺言: xxxxxxxxxxxxxxxx
```

-> 

```
[Jail] プレイヤー「xxxxx」が遺言を残しました。
[Jail] 遺言: xxxxxxxxxxxxxxxx
```