### PR TITLE
fix: #561 kill @sを除外

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/event/Event_AntiProblemCommand.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_AntiProblemCommand.java
@@ -107,7 +107,7 @@ public class Event_AntiProblemCommand extends MyMaidLibrary implements Listener,
             if (args.length == 1) {
                 return;
             }
-            if (args[1].equalsIgnoreCase("@p") || args[1].equalsIgnoreCase(player.getName())) {
+            if (args[1].equalsIgnoreCase("@p") || args[1].equalsIgnoreCase("@s") || args[1].equalsIgnoreCase(player.getName())) {
                 player.setHealth(0D);
                 event.setCancelled(true);
                 return;


### PR DESCRIPTION
- close #561

既に `/kill @p` 及び本人が自分をkillする場合はhistory追加等なかったので、`@s`だけ除外しました