### PR TITLE
fix: 南の楽園の場所を変更

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,6 @@
             <groupId>com.jaoafa</groupId>
             <artifactId>jaosuperachievement2</artifactId>
             <version>2.5.10</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.maxmind.geoip2</groupId>

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_EBan.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_EBan.java
@@ -97,7 +97,7 @@ public class Event_EBan implements Listener, EventPremise {
         if (!eban.isStatus()) return;
         World world = Bukkit.getServer().getWorld("Jao_Afa");
         if (world == null) return;
-        Location prison = new Location(world, 2856, 69, 2888);
+        Location prison = MyMaidData.paradiseLocation;
         if (!player.getLocation().getWorld().getUID().equals(world.getUID())) {
             player.sendMessage("[EBan] " + ChatColor.GREEN + "あなたは南の楽園から出られません！");
             // ワールド違い
@@ -131,8 +131,7 @@ public class Event_EBan implements Listener, EventPremise {
         EBan eban = EBan.getInstance(player);
         // EBanされてる
         if (!eban.isStatus()) return;
-        World World = Bukkit.getServer().getWorld("Jao_Afa");
-        Location prison = new Location(World, 2856, 69, 2888);
+        Location prison = MyMaidData.paradiseLocation;
         event.setRespawnLocation(prison);
     }
 

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_EBan.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_EBan.java
@@ -101,7 +101,7 @@ public class Event_EBan implements Listener, EventPremise {
         if (!player.getLocation().getWorld().getUID().equals(world.getUID())) {
             player.sendMessage("[EBan] " + ChatColor.GREEN + "あなたは南の楽園から出られません！");
             // ワールド違い
-            if (!MyMaidLibrary.teleportToParadise(player, TeleportCause.PLUGIN)) {
+            if (!MyMaidLibrary.teleportToParadise(player)) {
                 // 失敗時
                 Location oldBed = player.getBedSpawnLocation();
                 player.setBedSpawnLocation(prison, true);

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_EBan.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_EBan.java
@@ -101,7 +101,7 @@ public class Event_EBan implements Listener, EventPremise {
         if (!player.getLocation().getWorld().getUID().equals(world.getUID())) {
             player.sendMessage("[EBan] " + ChatColor.GREEN + "あなたは南の楽園から出られません！");
             // ワールド違い
-            if (!player.teleport(prison, TeleportCause.PLUGIN)) {
+            if (!MyMaidLibrary.teleportToParadise(player, TeleportCause.PLUGIN)) {
                 // 失敗時
                 Location oldBed = player.getBedSpawnLocation();
                 player.setBedSpawnLocation(prison, true);
@@ -131,8 +131,7 @@ public class Event_EBan implements Listener, EventPremise {
         EBan eban = EBan.getInstance(player);
         // EBanされてる
         if (!eban.isStatus()) return;
-        Location prison = MyMaidData.paradiseLocation;
-        event.setRespawnLocation(prison);
+        event.setRespawnLocation(MyMaidData.paradiseLocation);
     }
 
     @EventHandler

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_Jail.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_Jail.java
@@ -93,7 +93,7 @@ public class Event_Jail implements Listener, EventPremise {
         if (world == null) {
             return;
         }
-        Location prison = new Location(world, 2856, 69, 2888);
+        Location prison = MyMaidData.paradiseLocation;
         if (!player.getLocation().getWorld().getUID().equals(world.getUID())) {
             player.sendMessage("[Jail] " + ChatColor.GREEN + "あなたは南の楽園から出られません！");
             // ワールド違い
@@ -132,8 +132,7 @@ public class Event_Jail implements Listener, EventPremise {
             return;
         }
         World World = Bukkit.getServer().getWorld("Jao_Afa");
-        Location prison = new Location(World, 2856, 69, 2888);
-        event.setRespawnLocation(prison);
+        event.setRespawnLocation(MyMaidData.paradiseLocation);
     }
 
     @EventHandler

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_Jail.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_Jail.java
@@ -97,7 +97,8 @@ public class Event_Jail implements Listener, EventPremise {
         if (!player.getLocation().getWorld().getUID().equals(world.getUID())) {
             player.sendMessage("[Jail] " + ChatColor.GREEN + "あなたは南の楽園から出られません！");
             // ワールド違い
-            if (!player.teleport(prison, TeleportCause.PLUGIN)) {
+
+            if (!MyMaidLibrary.teleportToParadise(player, TeleportCause.PLUGIN)) {
                 // 失敗時
                 Location oldBed = player.getBedSpawnLocation();
                 player.setBedSpawnLocation(prison, true);
@@ -111,7 +112,7 @@ public class Event_Jail implements Listener, EventPremise {
             // 中央からの距離が50ブロック or y値が55未満
             player.sendMessage("[Jail] " + ChatColor.GREEN + "あなたは南の楽園から出られません！");
             if (distance >= 60D) {
-                if (!player.teleport(prison, TeleportCause.PLUGIN)) {
+                if (!MyMaidLibrary.teleportToParadise(player, TeleportCause.PLUGIN)) {
                     // 失敗時
                     Location oldBed = player.getBedSpawnLocation();
                     player.setBedSpawnLocation(prison, true);
@@ -131,7 +132,7 @@ public class Event_Jail implements Listener, EventPremise {
         if (!jail.isStatus()) { // Jailされてる
             return;
         }
-        World World = Bukkit.getServer().getWorld("Jao_Afa");
+
         event.setRespawnLocation(MyMaidData.paradiseLocation);
     }
 

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_Jail.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_Jail.java
@@ -36,6 +36,8 @@ import org.bukkit.event.player.*;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.util.UUID;
+
 public class Event_Jail implements Listener, EventPremise {
     @Override
     public String description() {
@@ -98,7 +100,7 @@ public class Event_Jail implements Listener, EventPremise {
             player.sendMessage("[Jail] " + ChatColor.GREEN + "あなたは南の楽園から出られません！");
             // ワールド違い
 
-            if (!MyMaidLibrary.teleportToParadise(player, TeleportCause.PLUGIN)) {
+            if (!MyMaidLibrary.teleportToParadise(player)) {
                 // 失敗時
                 Location oldBed = player.getBedSpawnLocation();
                 player.setBedSpawnLocation(prison, true);
@@ -108,11 +110,15 @@ public class Event_Jail implements Listener, EventPremise {
             return;
         }
         double distance = prison.distance(to);
-        if (distance >= 50D || to.getBlockY() < 55) {
-            // 中央からの距離が50ブロック or y値が55未満
-            player.sendMessage("[Jail] " + ChatColor.GREEN + "あなたは南の楽園から出られません！");
-            if (distance >= 60D) {
-                if (!MyMaidLibrary.teleportToParadise(player, TeleportCause.PLUGIN)) {
+        if (distance >= 65D || to.getBlockY() < 65) {
+            // 中央からの距離が65ブロック or y値が65未満
+            UUID uuid = player.getUniqueId();
+            if (!Jail.hasWarned.get(uuid))
+                player.sendMessage("[Jail] " + ChatColor.GREEN + "あなたは南の楽園から出られません！");
+            Jail.hasWarned.put(uuid,true);
+
+            if (distance >= 70D) {
+                if (!MyMaidLibrary.teleportToParadise(player)) {
                     // 失敗時
                     Location oldBed = player.getBedSpawnLocation();
                     player.setBedSpawnLocation(prison, true);

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_Jail.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_Jail.java
@@ -33,7 +33,6 @@ import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
 import org.bukkit.event.player.*;
-import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.UUID;
@@ -115,7 +114,7 @@ public class Event_Jail implements Listener, EventPremise {
             UUID uuid = player.getUniqueId();
             if (!Jail.hasWarned.get(uuid))
                 player.sendMessage("[Jail] " + ChatColor.GREEN + "あなたは南の楽園から出られません！");
-            Jail.hasWarned.put(uuid,true);
+            Jail.hasWarned.put(uuid, true);
 
             if (distance >= 70D) {
                 if (!MyMaidLibrary.teleportToParadise(player)) {

--- a/src/main/java/com/jaoafa/mymaid4/lib/EBan.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/EBan.java
@@ -150,9 +150,7 @@ public class EBan {
                         player.getPlayer().setGameMode(GameMode.CREATIVE);
                     }
 
-                    World Jao_Afa = Bukkit.getServer().getWorld("Jao_Afa");
-                    Location minami = new Location(Jao_Afa, 2856, 69, 2888);
-                    player.getPlayer().teleport(minami);
+                    player.getPlayer().teleport(MyMaidData.paradiseLocation);
                 }
 
                 fetchData(true);

--- a/src/main/java/com/jaoafa/mymaid4/lib/EBan.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/EBan.java
@@ -18,8 +18,9 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.bukkit.*;
-import org.bukkit.entity.Player;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.Nullable;
 
 import java.sql.*;
@@ -151,7 +152,7 @@ public class EBan {
                         player.getPlayer().setGameMode(GameMode.CREATIVE);
                     }
 
-                    MyMaidLibrary.teleportToParadise((Player) player);
+                    MyMaidLibrary.teleportToParadise(player.getPlayer());
                 }
 
                 fetchData(true);

--- a/src/main/java/com/jaoafa/mymaid4/lib/EBan.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/EBan.java
@@ -151,7 +151,7 @@ public class EBan {
                         player.getPlayer().setGameMode(GameMode.CREATIVE);
                     }
 
-                    MyMaidLibrary.teleportToParadise((Player) player, null);
+                    MyMaidLibrary.teleportToParadise((Player) player);
                 }
 
                 fetchData(true);

--- a/src/main/java/com/jaoafa/mymaid4/lib/EBan.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/EBan.java
@@ -19,6 +19,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.*;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
 
 import java.sql.*;
@@ -150,7 +151,7 @@ public class EBan {
                         player.getPlayer().setGameMode(GameMode.CREATIVE);
                     }
 
-                    player.getPlayer().teleport(MyMaidData.paradiseLocation);
+                    MyMaidLibrary.teleportToParadise((Player) player, null);
                 }
 
                 fetchData(true);

--- a/src/main/java/com/jaoafa/mymaid4/lib/Jail.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/Jail.java
@@ -156,9 +156,7 @@ public class Jail {
                         player.getPlayer().setGameMode(GameMode.CREATIVE);
                     }
 
-                    World Jao_Afa = Bukkit.getServer().getWorld("Jao_Afa");
-                    Location minami = new Location(Jao_Afa, 2856, 69, 2888);
-                    player.getPlayer().teleport(minami);
+                    player.getPlayer().teleport(MyMaidData.paradiseLocation);
                 }
 
                 Achievementjao.getAchievementAsync(player, Achievement.FIRSTJAIL); // No.22 はじめてのjail

--- a/src/main/java/com/jaoafa/mymaid4/lib/Jail.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/Jail.java
@@ -23,6 +23,7 @@ import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.*;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
 
 import java.sql.*;
@@ -156,7 +157,7 @@ public class Jail {
                         player.getPlayer().setGameMode(GameMode.CREATIVE);
                     }
 
-                    player.getPlayer().teleport(MyMaidData.paradiseLocation);
+                    MyMaidLibrary.teleportToParadise((Player) player, null);
                 }
 
                 Achievementjao.getAchievementAsync(player, Achievement.FIRSTJAIL); // No.22 はじめてのjail

--- a/src/main/java/com/jaoafa/mymaid4/lib/Jail.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/Jail.java
@@ -165,6 +165,8 @@ public class Jail {
 
                 Achievementjao.getAchievementAsync(player, Achievement.FIRSTJAIL); // No.22 はじめてのjail
 
+                Jail.hasWarned.put(player.getUniqueId(), false);
+
                 fetchData(true);
                 return Result.SUCCESS;
             }

--- a/src/main/java/com/jaoafa/mymaid4/lib/Jail.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/Jail.java
@@ -35,6 +35,8 @@ import java.util.*;
 public class Jail {
     static final Map<UUID, Jail> cache = new HashMap<>();
 
+    public static Map<UUID, Boolean> hasWarned = new HashMap<>();
+
     final OfflinePlayer player;
 
     /** Jail Id */
@@ -157,7 +159,7 @@ public class Jail {
                         player.getPlayer().setGameMode(GameMode.CREATIVE);
                     }
 
-                    MyMaidLibrary.teleportToParadise((Player) player, null);
+                    MyMaidLibrary.teleportToParadise((Player) player);
                 }
 
                 Achievementjao.getAchievementAsync(player, Achievement.FIRSTJAIL); // No.22 はじめてのjail
@@ -231,6 +233,8 @@ public class Jail {
                         Component.text("が使えるかもしれません。", NamedTextColor.GREEN)
                     ));
                 }
+
+                hasWarned.remove(player.getUniqueId());
 
                 fetchData(true);
                 return Result.SUCCESS;

--- a/src/main/java/com/jaoafa/mymaid4/lib/Jail.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/Jail.java
@@ -22,8 +22,9 @@ import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
-import org.bukkit.*;
-import org.bukkit.entity.Player;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.Nullable;
 
 import java.sql.*;
@@ -159,7 +160,7 @@ public class Jail {
                         player.getPlayer().setGameMode(GameMode.CREATIVE);
                     }
 
-                    MyMaidLibrary.teleportToParadise((Player) player);
+                    MyMaidLibrary.teleportToParadise(player.getPlayer());
                 }
 
                 Achievementjao.getAchievementAsync(player, Achievement.FIRSTJAIL); // No.22 はじめてのjail

--- a/src/main/java/com/jaoafa/mymaid4/lib/MyMaidData.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/MyMaidData.java
@@ -12,6 +12,7 @@
 package com.jaoafa.mymaid4.lib;
 
 import net.dv8tion.jda.api.entities.TextChannel;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -263,4 +264,9 @@ public class MyMaidData {
         }
         return jaoBoxPrevious.get(uuid);
     }
+
+    public static Location paradiseLocation = new Location(
+        Bukkit.getServer().getWorld("Jao_Afa"),
+        2856, 69, 2888
+    );
 }

--- a/src/main/java/com/jaoafa/mymaid4/lib/MyMaidLibrary.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/MyMaidLibrary.java
@@ -12,6 +12,7 @@
 package com.jaoafa.mymaid4.lib;
 
 import cloud.commandframework.context.CommandContext;
+import com.avaje.ebeaninternal.server.lib.util.NotFoundException;
 import com.jaoafa.mymaid4.Main;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -34,6 +35,7 @@ import org.bukkit.block.data.type.WallSign;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -608,6 +610,27 @@ public class MyMaidLibrary {
      */
     public static String formatLocation(Location loc) {
         return loc.getWorld().getName() + " " + loc.getBlockX() + " " + loc.getBlockY() + " " + loc.getBlockZ();
+    }
+
+    /**
+     * プレイヤーを南の楽園にテレポートさせます。
+     *
+     * @param player テレポートするプレイヤー
+     * @param teleportCause テレポートの原因
+     *
+     * @throws NotFoundException Jao_Afaワールドが存在しなかった場合
+     *
+     * @return テレポートに成功したかどうか
+     */
+    public static boolean teleportToParadise(Player player, @Nullable PlayerTeleportEvent.TeleportCause teleportCause) {
+        if (Bukkit.getWorld("Jao_Afa") == null)
+            throw new NotFoundException("World:Jao_Afa Not Found!");
+
+        Location paradise = MyMaidData.paradiseLocation;
+
+        if (teleportCause != null)
+            return player.teleport(paradise,teleportCause);
+        else return player.teleport(paradise);
     }
 
     /**

--- a/src/main/java/com/jaoafa/mymaid4/lib/MyMaidLibrary.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/MyMaidLibrary.java
@@ -12,7 +12,6 @@
 package com.jaoafa.mymaid4.lib;
 
 import cloud.commandframework.context.CommandContext;
-import com.avaje.ebeaninternal.server.lib.util.NotFoundException;
 import com.jaoafa.mymaid4.Main;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -616,21 +615,19 @@ public class MyMaidLibrary {
      * プレイヤーを南の楽園にテレポートさせます。
      *
      * @param player テレポートするプレイヤー
-     * @param teleportCause テレポートの原因
-     *
-     * @throws NotFoundException Jao_Afaワールドが存在しなかった場合
      *
      * @return テレポートに成功したかどうか
+     *
+     * @throws IllegalStateException Jao_Afaワールドが存在しなかった場合
      */
-    public static boolean teleportToParadise(Player player, @Nullable PlayerTeleportEvent.TeleportCause teleportCause) {
+    public static boolean teleportToParadise(Player player) {
         if (Bukkit.getWorld("Jao_Afa") == null)
-            throw new NotFoundException("World:Jao_Afa Not Found!");
+            throw new IllegalStateException("World:Jao_Afa Not Found!");
 
-        Location paradise = MyMaidData.paradiseLocation;
-
-        if (teleportCause != null)
-            return player.teleport(paradise,teleportCause);
-        else return player.teleport(paradise);
+        return player.teleport(
+            MyMaidData.paradiseLocation,
+            PlayerTeleportEvent.TeleportCause.PLUGIN
+        );
     }
 
     /**


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

南の楽園の場所を修正しました。

## 関連する Issue

> close #726 

## チェックリスト

> `[ ]` を `[x]` にすることでチェックできます

- [x] 【必須】[CONTRIBUTING](https://github.com/jaoafa/MyMaid4/blob/master/CONTRIBUTING.md) を読みました
- [ ] 【必須】テストサーバで動作確認をしました
    - [ ] ローカルサーバで動作確認しました
    - [ ] ZakuroHatのテストサーバで動作確認しました
- [x] 【必須】プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- [x] 【必須】`NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [x] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
    - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [x] 複数のクラスにわたって使用される変数があるので、 `MyMaidData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `MyMaidLibrary` にその関数を作成し管理しています

## 追加情報

DBがなくてjailできないので、✞本番環境でテスト✞になってしまうかも...


