### PR TITLE
feat: tipsコマンドの実装

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_Tips.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_Tips.java
@@ -1,0 +1,127 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2022 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.mymaid4.command;
+
+import cloud.commandframework.ArgumentDescription;
+import cloud.commandframework.Command;
+import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.meta.CommandMeta;
+import com.jaoafa.mymaid4.lib.*;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class Cmd_Tips extends MyMaidLibrary implements CommandPremise {
+    @Override
+    public MyMaidCommand.Detail details() {
+        return new MyMaidCommand.Detail(
+            "tips",
+            "Tipsの定型文を投稿・管理します。"
+        );
+    }
+
+    @Override
+    public MyMaidCommand.Cmd register(Command.Builder<CommandSender> builder) {
+        return new MyMaidCommand.Cmd(
+            builder
+                .meta(CommandMeta.DESCRIPTION, "Tipsを追加します。")
+                .literal("add", "a", "register", "reg")
+                .argument(StringArgument.of("name"), ArgumentDescription.of("Tipsの名前"))
+                .argument(StringArgument.greedy("text"), ArgumentDescription.of("Tipsの文章"))
+                .handler(this::addTip)
+                .build(),
+            builder
+                .meta(CommandMeta.DESCRIPTION, "Tipsを削除します。")
+                .literal("remove", "rem", "del", "r", "d", "unregister", "unreg")
+                .argument(StringArgument.of("name"), ArgumentDescription.of("Tipsの名前"))
+                .handler(this::removeTip)
+                .build(),
+            builder
+                .meta(CommandMeta.DESCRIPTION, "Tipsを表示します。")
+                .literal("list", "l", "view", "v")
+                .handler(this::listTip)
+                .build(),
+            builder
+                .meta(CommandMeta.DESCRIPTION, "Tipsを送信・発言します。")
+                .literal("broadcast", "b", "send", "s", "say")
+                .argument(StringArgument.<CommandSender>newBuilder("name").withSuggestionsProvider(this::suggestTipNames), ArgumentDescription.of("Tipsの名前"))
+                .handler(this::broadcastTip)
+                .build()
+        );
+    }
+
+    void addTip(CommandContext<CommandSender> context) {
+        CommandSender sender = context.getSender();
+        String name = context.get("name");
+        String text = context.get("text");
+
+        if (Tips.isExist(name)) {
+            SendMessage(sender, details(), "「%s」は既に存在しています。".formatted(name));
+            return;
+        }
+
+        Tips.addTip(name, text);
+        SendMessage(sender, details(), "「%s」を追加しました。".formatted(name));
+    }
+
+    void removeTip(CommandContext<CommandSender> context) {
+        CommandSender sender = context.getSender();
+        String name = context.get("name");
+
+        if (!Tips.isExist(name)) {
+            SendMessage(sender, details(), "「%s」は存在しません。".formatted(name));
+            return;
+        }
+
+        Tips.removeTip(name);
+        SendMessage(sender, details(), "「%s」を削除しました。".formatted(name));
+    }
+
+    void listTip(CommandContext<CommandSender> context) {
+        CommandSender sender = context.getSender();
+
+        SendMessage(sender, details(), "Tips 一覧");
+        for (Map.Entry<String, String> entry : Tips.getTips().entrySet()) {
+            SendMessage(sender, details(), "- %s: %s".formatted(entry.getKey(), entry.getValue()));
+        }
+    }
+
+    void broadcastTip(CommandContext<CommandSender> context) {
+        CommandSender sender = context.getSender();
+        String name = context.get("name");
+
+        TextColor color = NamedTextColor.GRAY;
+        if (sender instanceof Player) {
+            SKKColorManager.getPlayerColor((Player) sender);
+        }
+
+        if (!Tips.isExist(name)) {
+            SendMessage(sender, details(), "「%s」は存在しません。".formatted(name));
+            return;
+        }
+
+        String text = Tips.getTip(name);
+        chatFake(color, sender.getName(), text);
+    }
+
+    List<String> suggestTipNames(final CommandContext<CommandSender> context, final String current) {
+        return Tips.getTips().keySet().stream()
+            .filter(name -> name.startsWith(current))
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/jaoafa/mymaid4/lib/MyMaidLibrary.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/MyMaidLibrary.java
@@ -23,6 +23,7 @@ import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.luckperms.api.LuckPerms;
@@ -399,7 +400,7 @@ public class MyMaidLibrary {
      * @param name  プレイヤー名
      * @param text  テキスト
      */
-    public static void chatFake(NamedTextColor color, String name, String text) {
+    public static void chatFake(TextColor color, String name, String text) {
         chatFake(color, name, text, true);
     }
 
@@ -411,7 +412,7 @@ public class MyMaidLibrary {
      * @param text          テキスト
      * @param sendToDiscord Discordにも送信するか
      */
-    public static void chatFake(NamedTextColor color, String name, String text, boolean sendToDiscord) {
+    public static void chatFake(TextColor color, String name, String text, boolean sendToDiscord) {
         chatFake(color, name, Component.text(text), sendToDiscord);
     }
 
@@ -423,7 +424,7 @@ public class MyMaidLibrary {
      * @param component     テキスト
      * @param sendToDiscord Discordにも送信するか
      */
-    public static void chatFake(NamedTextColor color, String name, Component component, boolean sendToDiscord) {
+    public static void chatFake(TextColor color, String name, Component component, boolean sendToDiscord) {
         Bukkit.getServer().sendMessage(Component.text().append(
             Component.text("[" + sdfTimeFormat(new Date()) + "]", NamedTextColor.GRAY),
             Component.text("■", color),

--- a/src/main/java/com/jaoafa/mymaid4/lib/Tips.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/Tips.java
@@ -89,7 +89,7 @@ public class Tips {
                 tips.put(key, object.getString(key));
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            MyMaidLibrary.reportError(Tips.class, e);
         }
     }
 
@@ -101,7 +101,7 @@ public class Tips {
         try {
             Files.writeString(path, object.toString());
         } catch (IOException e) {
-            e.printStackTrace();
+            MyMaidLibrary.reportError(Tips.class, e);
         }
     }
 }

--- a/src/main/java/com/jaoafa/mymaid4/lib/Tips.java
+++ b/src/main/java/com/jaoafa/mymaid4/lib/Tips.java
@@ -1,0 +1,107 @@
+/*
+ * jaoLicense
+ *
+ * Copyright (c) 2022 jao Minecraft Server
+ *
+ * The following license applies to this project: jaoLicense
+ *
+ * Japanese: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE.md
+ * English: https://github.com/jaoafa/jao-Minecraft-Server/blob/master/jaoLICENSE-en.md
+ */
+
+package com.jaoafa.mymaid4.lib;
+
+import com.jaoafa.mymaid4.Main;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Tips {
+    private static final Path path = Path.of(Main.getJavaPlugin().getDataFolder().getAbsolutePath(), "tips.json");
+    private static final Map<String, String> tips = new HashMap<>();
+
+    /**
+     * name から Tip を取得する
+     *
+     * @param name Tip の名前
+     *
+     * @return Tip (存在しない場合は NULL)
+     */
+    public static String getTip(String name) {
+        if (tips.isEmpty()) {
+            loadTips();
+        }
+        return tips.get(name);
+    }
+
+    /**
+     * すべての Tip を取得する
+     *
+     * @return Tip の Map
+     */
+    public static Map<String, String> getTips() {
+        if (tips.isEmpty()) {
+            loadTips();
+        }
+        return tips;
+    }
+
+    public static boolean isExist(String name) {
+        if (tips.isEmpty()) {
+            loadTips();
+        }
+        return tips.containsKey(name);
+    }
+
+    /**
+     * Tip を追加する
+     *
+     * @param name Tip の名前
+     * @param text Tip のテキスト
+     */
+    public static void addTip(String name, String text) {
+        tips.put(name, text);
+        saveTips();
+    }
+
+    /**
+     * Tip を削除する
+     *
+     * @param name Tip の名前
+     */
+    public static void removeTip(String name) {
+        tips.remove(name);
+        saveTips();
+    }
+
+    private static void loadTips() {
+        if (!Files.exists(path)) {
+            return;
+        }
+        tips.clear();
+        try {
+            JSONObject object = new JSONObject(Files.readString(path));
+            for (String key : object.keySet()) {
+                tips.put(key, object.getString(key));
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void saveTips() {
+        JSONObject object = new JSONObject();
+        for (String key : tips.keySet()) {
+            object.put(key, tips.get(key));
+        }
+        try {
+            Files.writeString(path, object.toString());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
close #842

定型文送信・管理コマンド `tips` を実装します。

「どこにいるの？」に対する「DynmapURLの送信」、「.って何？」に対する文化に関するページへのリンクなど、よくある質問や応対のために利用できると思います。

- `/tips add <TipName> <Text>`: TipNameでTextを登録します。
- `/tips remove <TipName>`: TipNameのTipを削除します。
- `/tips broadcast <TipName>`: TipNameに紐づいたTip (Text)を送信します。メッセージはフェイクチャットとして投稿されます。
- `/tips list`: Tipsの一覧を表示します。