### PR TITLE
/g で引数に大文字を指定できない問題を修正

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_G.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_G.java
@@ -75,6 +75,17 @@ public class Cmd_G extends MyMaidLibrary implements CommandPremise {
         );
     }
 
+    void sendChangeNotify(Player player, String before, String after) {
+        SendMessage(player, details(), Component.text().append(
+            Component.text("ゲームモードを切り替えました: ", NamedTextColor.GREEN),
+            Component.text(before, NamedTextColor.GREEN)
+                .hoverEvent(HoverEvent.showText(Component.text(MessageFormat.format("{0} にゲームモードを変更します", before))))
+                .clickEvent(ClickEvent.runCommand(String.format("/g %s", before))),
+            Component.text(" -> ", NamedTextColor.GREEN),
+            Component.text(after, NamedTextColor.GREEN, TextDecoration.BOLD)
+        ).build());
+    }
+
     void autoChangeGamemode(CommandContext<CommandSender> context) {
         Player player = (Player) context.getSender();
         GameMode beforeGamemode = player.getGameMode();
@@ -89,25 +100,11 @@ public class Cmd_G extends MyMaidLibrary implements CommandPremise {
             }
 
             player.setGameMode(GameMode.SPECTATOR);
-            SendMessage(player, details(), Component.text().append(
-                Component.text("ゲームモードを切り替えました: ", NamedTextColor.GREEN),
-                Component.text(beforeGamemode.name(), NamedTextColor.GREEN)
-                    .hoverEvent(HoverEvent.showText(Component.text(MessageFormat.format("{0} にゲームモードを変更します", beforeGamemode.name()))))
-                    .clickEvent(ClickEvent.runCommand(String.format("/g %s", beforeGamemode.name()))),
-                Component.text(" -> ", NamedTextColor.GREEN),
-                Component.text("SPECTATOR", NamedTextColor.GREEN, TextDecoration.BOLD)
-            ).build());
         } else {
             player.setGameMode(GameMode.CREATIVE);
-            SendMessage(player, details(), Component.text().append(
-                Component.text("ゲームモードを切り替えました: ", NamedTextColor.GREEN),
-                Component.text(beforeGamemode.name(), NamedTextColor.GREEN)
-                    .hoverEvent(HoverEvent.showText(Component.text(MessageFormat.format("{0} にゲームモードを変更します", beforeGamemode.name()))))
-                    .clickEvent(ClickEvent.runCommand(String.format("/g %s", beforeGamemode.name()))),
-                Component.text(" -> ", NamedTextColor.GREEN),
-                Component.text(player.getGameMode().name(), NamedTextColor.GREEN, TextDecoration.BOLD)
-            ).build());
         }
+
+        sendChangeNotify(player, beforeGamemode.name(), player.getGameMode().name());
     }
 
     void changeGamemode(CommandContext<CommandSender> context) {
@@ -134,14 +131,8 @@ public class Cmd_G extends MyMaidLibrary implements CommandPremise {
         }
 
         player.setGameMode(gamemode);
-        SendMessage(player, details(), Component.text().append(
-            Component.text("ゲームモードを切り替えました: ", NamedTextColor.GREEN),
-            Component.text(beforeGamemode.name(), NamedTextColor.GREEN)
-                .hoverEvent(HoverEvent.showText(Component.text(MessageFormat.format("{0} にゲームモードを変更します", beforeGamemode.name()))))
-                .clickEvent(ClickEvent.runCommand(String.format("/g %s", beforeGamemode.name()))),
-            Component.text(" -> ", NamedTextColor.GREEN),
-            Component.text(player.getGameMode().name(), NamedTextColor.GREEN, TextDecoration.BOLD)
-        ).build());
+
+        sendChangeNotify(player, beforeGamemode.name(), player.getGameMode().name());
     }
 
     void changePlayerGamemode(CommandContext<CommandSender> context) {

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_G.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_G.java
@@ -198,7 +198,7 @@ public class Cmd_G extends MyMaidLibrary implements CommandPremise {
             Component.text("Creative -> c / 1 / creative", NamedTextColor.WHITE)
                 .clickEvent(ClickEvent.runCommand("/g c")),
             Component.newline(),
-            Component.text("Advanture -> a / 2 / advanture", NamedTextColor.RED)
+            Component.text("Adventure -> a / 2 / adventure", NamedTextColor.RED)
                 .clickEvent(ClickEvent.runCommand("/g a")),
             Component.newline(),
             Component.text("Spectator -> sp / 3 / spectator", NamedTextColor.YELLOW)

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_G.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_G.java
@@ -231,7 +231,7 @@ public class Cmd_G extends MyMaidLibrary implements CommandPremise {
                 return GameMode.SPECTATOR;
         }
         for (GameMode mode : GameMode.values()) {
-            if (mode.name().toLowerCase().startsWith(str)) {
+            if (mode.name().toLowerCase().startsWith(str.toLowerCase())) {
                 return mode;
             }
         }


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

- タイトル通りの修正をしました。
- ユーザーへメッセージを送るコードの一部が重複していたので、まとめました。
- `Adventure` が `Advanture` となっていたので、これも修正しました。

## 関連する Issue

close #890 

## チェックリスト

> `[ ]` を `[x]` にすることでチェックできます

- [x] 【必須】[CONTRIBUTING](https://github.com/jaoafa/MyMaid4/blob/master/CONTRIBUTING.md) を読みました
- [x] 【必須】テストサーバで動作確認をしました
    - [ ] ローカルサーバで動作確認しました
    - [x] ZakuroHatのテストサーバで動作確認しました
- [x] 【必須】プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- [x] 【必須】`NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [ ] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
    - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [ ] 複数のクラスにわたって使用される変数があるので、 `MyMaidData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `MyMaidLibrary` にその関数を作成し管理しています

## 追加情報

> 何か追加情報がある場合は記載してください


