### PR TITLE
/walkspeed,flyspeed reset を実装 & デフォルト値を修正

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_FlySpeed.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_FlySpeed.java
@@ -49,6 +49,12 @@ public class Cmd_FlySpeed extends MyMaidLibrary implements CommandPremise {
                 .literal("set")
                 .argument(FloatArgument.of("percent"), ArgumentDescription.of("クリエイティブ飛行速度(通常100%)"))
                 .handler(this::setFlySpeed)
+                .build(),
+            builder
+                .meta(CommandMeta.DESCRIPTION, "クリエイティブ飛行速度を初期化します。")
+                .senderType(Player.class)
+                .literal("reset")
+                .handler(this::resetFlySpeed)
                 .build()
         );
     }
@@ -66,11 +72,9 @@ public class Cmd_FlySpeed extends MyMaidLibrary implements CommandPremise {
         }
         float speed = MyMaidData.getFlySpeed(target.getUniqueId()) * 1000;
         SendMessage(sender, details(), Component.text().append(
-            Component.text(sender == target ? "あなた" : target.getName(), NamedTextColor.GREEN),
-            Component.text("のクリエイティブ飛行速度は", NamedTextColor.GREEN),
+            Component.text((sender == target ? "あなた" : target.getName()) + "のクリエイティブ飛行速度は", NamedTextColor.GREEN),
             Component.space(),
-            Component.text(speed, NamedTextColor.GREEN),
-            Component.text("%", NamedTextColor.GREEN),
+            Component.text(speed + "%", NamedTextColor.GREEN),
             Component.space(),
             Component.text("です。", NamedTextColor.GREEN)
         ).build());
@@ -78,19 +82,26 @@ public class Cmd_FlySpeed extends MyMaidLibrary implements CommandPremise {
 
     void setFlySpeed(CommandContext<CommandSender> context) {
         Player player = (Player) context.getSender();
-        float speed = context.<Float>get("percent") / 1000;
-        if (speed < -1 || speed > 1) {
+        float speedFloat = context.<Float>get("percent") / 1000;
+        if (speedFloat < -1 || speedFloat > 1) {
             SendMessage(player, details(), "値は 1000% から -1000% を指定できます。");
             return;
         }
-        MyMaidData.setFlySpeed(player.getUniqueId(), speed);
+        MyMaidData.setFlySpeed(player.getUniqueId(), speedFloat);
         SendMessage(player, details(), Component.text().append(
             Component.text("あなたのクリエイティブ飛行速度を", NamedTextColor.GREEN),
             Component.space(),
-            Component.text(speed * 1000, NamedTextColor.GREEN),
-            Component.text("%", NamedTextColor.GREEN),
+            Component.text((speedFloat * 1000) + "%", NamedTextColor.GREEN),
             Component.space(),
             Component.text("に変更しました。", NamedTextColor.GREEN)
+        ).build());
+    }
+
+    void resetFlySpeed(CommandContext<CommandSender> context) {
+        Player player = (Player) context.getSender();
+        MyMaidData.setFlySpeed(player.getUniqueId(), 0.1f);
+        SendMessage(player, details(), Component.text().append(
+            Component.text("あなたのクリエイティブ飛行速度を初期化しました。", NamedTextColor.GREEN)
         ).build());
     }
 }

--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_WalkSpeed.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_WalkSpeed.java
@@ -48,8 +48,14 @@ public class Cmd_WalkSpeed extends MyMaidLibrary implements CommandPremise {
                 .senderType(Player.class)
                 .literal("set")
                 .argument(FloatArgument.of("percent"),
-                    ArgumentDescription.of("移動速度(通常100%)"))
+                    ArgumentDescription.of("移動速度(通常200%)"))
                 .handler(this::setWalkSpeed)
+                .build(),
+            builder
+                .meta(CommandMeta.DESCRIPTION, "移動速度を初期化します。")
+                .senderType(Player.class)
+                .literal("reset")
+                .handler(this::resetWalkSpeed)
                 .build()
         );
     }
@@ -67,11 +73,9 @@ public class Cmd_WalkSpeed extends MyMaidLibrary implements CommandPremise {
         }
         float speed = target.getWalkSpeed() * 1000;
         SendMessage(sender, details(), Component.text().append(
-            Component.text(sender == target ? "あなた" : target.getName(), NamedTextColor.GREEN),
-            Component.text("の移動速度は", NamedTextColor.GREEN),
+            Component.text((sender == target ? "あなた" : target.getName()) + "の移動速度は", NamedTextColor.GREEN),
             Component.space(),
-            Component.text(speed, NamedTextColor.GREEN),
-            Component.text("%", NamedTextColor.GREEN),
+            Component.text(speed + "%", NamedTextColor.GREEN),
             Component.space(),
             Component.text("です。", NamedTextColor.GREEN)
         ).build());
@@ -79,19 +83,26 @@ public class Cmd_WalkSpeed extends MyMaidLibrary implements CommandPremise {
 
     void setWalkSpeed(CommandContext<CommandSender> context) {
         Player player = (Player) context.getSender();
-        float speed = context.<Float>get("percent") / 1000;
-        if (speed < -1 || speed > 1) {
+        float speedFloat = context.<Float>get("percent") / 1000;
+        if (speedFloat < -1 || speedFloat > 1) {
             SendMessage(player, details(), "値は 1000% から -1000% を指定できます。");
             return;
         }
-        player.setWalkSpeed(speed);
+        player.setWalkSpeed(speedFloat);
         SendMessage(player, details(), Component.text().append(
             Component.text("あなたの移動速度を", NamedTextColor.GREEN),
             Component.space(),
-            Component.text(speed * 1000, NamedTextColor.GREEN),
-            Component.text("%", NamedTextColor.GREEN),
+            Component.text((speedFloat * 1000) + "%", NamedTextColor.GREEN),
             Component.space(),
             Component.text("に変更しました。", NamedTextColor.GREEN)
+        ).build());
+    }
+
+    void resetWalkSpeed(CommandContext<CommandSender> context) {
+        Player player = (Player) context.getSender();
+        player.setWalkSpeed(0.2f);
+        SendMessage(player, details(), Component.text().append(
+            Component.text("あなたの移動速度を初期化しました。", NamedTextColor.GREEN)
         ).build());
     }
 }


### PR DESCRIPTION
## 実装・修正した内容の簡単な解説

- `/walkspeed reset` `/flyspeed reset` を実装しました。
- walkspeed のデフォルト値を修正しました。(`0.1f` -> `0.2f`)

## 関連する Issue

- close #897
- close #898 

## チェックリスト

> `[ ]` を `[x]` にすることでチェックできます

- [x] 【必須】[CONTRIBUTING](https://github.com/jaoafa/MyMaid4/blob/master/CONTRIBUTING.md) を読みました
- [x] 【必須】テストサーバで動作確認をしました
    - [ ] ローカルサーバで動作確認しました
    - [x] ZakuroHatのテストサーバで動作確認しました
- [x] 【必須】プロジェクトのコードスタイルに適合しています（IDEAのコミット前処理でフォーマットして下さい）
- [x] 【必須】`NULL` が返却されるかもしれない(`@Nullable`)メソッドや変数は NULL チェックを実装しました
- [x] 非推奨とされているメソッド・クラスなどを使用していません（なるべく推奨されるメソッドなどに置き換える）
    - [ ] 代替メソッド・クラスなどがないため、非推奨メソッドなどを使用しています
- [ ] 複数のクラスにわたって使用される変数があるので、 `MyMaidData` にその変数を作成し管理しています
- [ ] 複数のクラスにわたって多く使用される関数があるので、 `MyMaidLibrary` にその関数を作成し管理しています

## 追加情報

> 何か追加情報がある場合は記載してください


