### PR TITLE
fix: プレイヤーの頭がツールバー判定される問題の修正

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/event/Event_AntiToolbar.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_AntiToolbar.java
@@ -38,6 +38,24 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.regex.Pattern;
 
+/**
+ * ツールバーの利用を制限します。
+ * <p>
+ * ・クリエイティブモードでクリエイティブインベントリやツールバーからアイテムをインベントリに追加する際に {@link InventoryCreativeEvent} が発生することを利用して制限します。
+ * ・この機能は Admin, Moderator, Regular には適用されません。
+ * ・クリエイティブインベントリに存在するアイテムの一覧はデータフォルダにある creative-items.tsv で定義します。これが未定義の場合はこの機能は動作しません。
+ * → このファイルはフラグ isCollectCreativeItems を True にし、クリエイティブインベントリにあるアイテムをすべて入手（ドロップ）することで出力できます。
+ * <p>
+ * ・クリエイティブインベントリのアイテムと {@link InventoryCreativeEvent#getCursor()} が合致する場合、除外します。
+ * ・InventoryCreativeEvent 発生時、{@link InventoryCreativeEvent#getCurrentItem()} が NULL ではなく AIR ではない場合はアイテムを持ち上げたものとして Map に記録します。
+ * → さらに、次のイベント発生時に記録したアイテムと {@link InventoryCreativeEvent#getCursor()} が合致する場合はツールバーからの取得とみなしません。
+ * → これにより、一度持ち上げて別のスロットに移動させた場合にツールバーとして判定されなくなります。(#429, #913)
+ * ・jaoiumに該当するアイテムは処罰対象としてその後処理されるため、この機能では当該アイテムを削除しません。
+ * ・ImageOnMapのマップをマウス中クリックでコピーするとツールバーとして誤認されてしまう問題を回避するため、{@link Material#FILLED_MAP} のアイテムはすべて除外します。(#533)
+ * <p>
+ * 以上のフローを経て、除外されなかったアイテムはすべてツールバーとして判定し、当該アイテムを削除します。
+ * また当該アイテムの情報をデータフォルダの toolbar-items.tsv に記録します。
+ */
 public class Event_AntiToolbar extends MyMaidLibrary implements Listener, EventPremise {
     final Pattern damagePattern = Pattern.compile("\\{Damage:\\d+}");
     final Map<UUID, ItemStack> pickupItems = new HashMap<>();


### PR DESCRIPTION
- close #896 

ツールバー関連は仕組みがごちゃごちゃしているので、結構ツラいです。

このプルリクエストに紐付くIssueは #896 だけですが、多分 #429 とかも関係してくるんだろうと思います。
とりあえず今回で対応したものは次の2つです。

- 持ち上げたアイテムとして除外された時に入れ替わりで持ち上げたアイテム（頭スロットに既にあるアイテムをアイテムを持った状態で置き換えるなど）を他のスロットに置くとツールバーアイテム判定される問題
- 特殊な条件で起こるプレイヤーの頭のNBTデータ不一致問題
  - `head` や `give` コマンドで入手したプレイヤーの頭には、頭として指定したプレイヤーのプレイヤー名やUUIDしか含まれていません。
  - そのアイテムを持ち上げるなどすることで、そのプレイヤー情報に紐付くスキン情報（プロファイルデータ）が追記されます。
  - これによって元々インベントリにあったアイテム情報と持ち上げた後移動したアイテム情報が不一致と判断され、ユーザからすると同一アイテムに見えるものがシステム的に同一ではなくなる…という面倒なことになっていました
  - `isAllowPlayerHead` メソッドを作成し、プレイヤー名やUUIDが合致する場合は同一アイテムとして判定することで回避します。（逆に、この回避策はツールバーに細工されたプレイヤーの頭を入れておくことでツールバー判定を回避できるので難しいところです）

今後のためにクラスコメントをつけておきました。