### PR TITLE
feat: gコマンドにgamemodeエイリアスを追加

### DIFF
--- a/src/main/java/com/jaoafa/mymaid4/command/Cmd_G.java
+++ b/src/main/java/com/jaoafa/mymaid4/command/Cmd_G.java
@@ -1,7 +1,7 @@
 /*
  * jaoLicense
  *
- * Copyright (c) 2022 jao Minecraft Server
+ * Copyright (c) 2023 jao Minecraft Server
  *
  * The following license applies to this project: jaoLicense
  *
@@ -34,7 +34,6 @@ import org.jetbrains.annotations.Nullable;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -43,7 +42,7 @@ public class Cmd_G extends MyMaidLibrary implements CommandPremise {
     public MyMaidCommand.Detail details() {
         return new MyMaidCommand.Detail(
             "g",
-            Collections.singletonList("gm"),
+            List.of("gm", "gamemode"),
             "ゲームモードを変更します。"
         );
     }

--- a/src/main/java/com/jaoafa/mymaid4/event/Event_GameModeCmd.java
+++ b/src/main/java/com/jaoafa/mymaid4/event/Event_GameModeCmd.java
@@ -1,7 +1,7 @@
 /*
  * jaoLicense
  *
- * Copyright (c) 2022 jao Minecraft Server
+ * Copyright (c) 2023 jao Minecraft Server
  *
  * The following license applies to this project: jaoLicense
  *
@@ -23,7 +23,7 @@ import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 public class Event_GameModeCmd extends MyMaidLibrary implements Listener, EventPremise {
     @Override
     public String description() {
-        return "gamemodeコマンドが実行された際に、gコマンドを勧めます。";
+        return "minecraft:gamemodeコマンドが実行された際に、gコマンドを勧めます。";
     }
 
     @EventHandler
@@ -34,8 +34,7 @@ public class Event_GameModeCmd extends MyMaidLibrary implements Listener, EventP
         if (args.length == 0) {
             return; // 本来発生しないと思うけど
         }
-        if (!args[0].equalsIgnoreCase("/gamemode")
-            && !args[0].equalsIgnoreCase("/minecraft:gamemode")) {
+        if (!args[0].equalsIgnoreCase("/minecraft:gamemode")) {
             return; // gamemodeコマンド以外
         }
         if (isAMRV(player)) {


### PR DESCRIPTION
- close #1004 

g コマンドに gamemode エイリアスを追加します。これにより、数字でゲームモードを変更しようとするユーザーもカバーできるようになるかと思います。
なお、この変更によって「gamemodeコマンドを実行したときにgコマンドを勧める機能」は「`minecraft:gamemode`を実行したときのみ」になりました。